### PR TITLE
Adds the ability for users to prepend/append their own path requirements

### DIFF
--- a/gradle-python-oss/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
+++ b/gradle-python-oss/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
@@ -19,6 +19,7 @@ import com.linkedin.gradle.python.util.internal.ExecutablePathUtils;
 import org.gradle.api.Project;
 
 import java.io.File;
+import java.util.List;
 
 
 public class PythonDetails {
@@ -31,6 +32,8 @@ public class PythonDetails {
     private String virtualEnvPrompt;
     private PythonVersion pythonVersion;
 
+    private List<File> searchPath;
+
     public PythonDetails(Project project, File virtualenvLocation) {
         this.project = project;
         pythonInterpreter = new File("/usr/bin/python");
@@ -39,6 +42,7 @@ public class PythonDetails {
         virtualEnv = virtualenvLocation;
         activateLink = new File(project.getProjectDir(), "activate");
         virtualEnvPrompt = String.format("(%s)", project.getName());
+        searchPath = ExecutablePathUtils.getPath();
     }
 
     private void updateFromPythonInterpreter() {
@@ -76,6 +80,26 @@ public class PythonDetails {
         this.activateLink = activateLink;
     }
 
+    /**
+     * Adds a new directory to search for an executable. This is like adding the directory to the
+     * <strong>beginning</strong> of PATH
+     *
+     * @param file directory to search for an executable
+     */
+    public void prependExecuableDirectory(File file) {
+        searchPath.add(0, file);
+    }
+
+    /**
+     * Adds a new directory to search for an executable. This is like adding the directory to the <strong>end</strong>
+     * of PATH
+     *
+     * @param file directory to search for an executable
+     */
+    public void appendExecuableDirectory(File file) {
+        searchPath.add(file);
+    }
+
     public void setPythonVersion(String pythonVersion) {
         if ("2".equals(pythonVersion)) {
             pythonVersion = "2.6";
@@ -85,11 +109,7 @@ public class PythonDetails {
             pythonVersion = "3.5";
         }
 
-        pythonInterpreter = ExecutablePathUtils.getExecutable(String.format("python%s", pythonVersion));
-        if (null == pythonInterpreter) {
-            //TODO: Make this configurable for others
-            pythonInterpreter = new File(String.format("/export/apps/python/%s/bin/python%s", pythonVersion, pythonVersion));
-        }
+        pythonInterpreter = ExecutablePathUtils.getExecutable(searchPath, String.format("python%s", pythonVersion));
         updateFromPythonInterpreter();
     }
 

--- a/gradle-python-oss/src/main/groovy/com/linkedin/gradle/python/util/internal/ExecutablePathUtils.java
+++ b/gradle-python-oss/src/main/groovy/com/linkedin/gradle/python/util/internal/ExecutablePathUtils.java
@@ -17,7 +17,6 @@ package com.linkedin.gradle.python.util.internal;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -27,8 +26,8 @@ public class ExecutablePathUtils {
         //private constructor for util class
     }
 
-    public static File getExecutable(String exeName) {
-        for (File dir : getPath()) {
+    public static File getExecutable(List<File> pathList, String exeName) {
+        for (File dir : pathList) {
             File candidate = new File(dir, exeName);
             if (candidate.isFile()) {
                 return candidate;
@@ -38,11 +37,13 @@ public class ExecutablePathUtils {
     }
 
     public static List<File> getPath() {
+        List<File> entries = new ArrayList<>();
+
         String path = System.getenv("PATH");
         if (path == null) {
-            return Collections.emptyList();
+            return entries;
         }
-        List<File> entries = new ArrayList<>();
+
         for (String entry : path.split(Pattern.quote(File.pathSeparator))) {
             entries.add(new File(entry));
         }

--- a/gradle-python-oss/src/test/groovy/com/linkedin/gradle/python/util/internal/ExecutablePathUtilsTest.groovy
+++ b/gradle-python-oss/src/test/groovy/com/linkedin/gradle/python/util/internal/ExecutablePathUtilsTest.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.util.internal
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+
+class ExecutablePathUtilsTest extends Specification {
+
+    @Rule
+    TemporaryFolder temporaryFolder
+
+    def 'can pre-pend a folder to the search path'() {
+        temporaryFolder.newFolder("foo")
+        temporaryFolder.newFolder("bar")
+        def fooExample = temporaryFolder.newFile('foo/example.sh')
+        def barExample = temporaryFolder.newFile('bar/example.sh')
+
+        expect:
+        ExecutablePathUtils.getExecutable([fooExample.parentFile, barExample.parentFile], 'example.sh') == fooExample
+    }
+}


### PR DESCRIPTION
- Adds a new test for ExecutablePathUtils (there was never one)
- Added test for 'fake pythons' to validate the resolution path works
  like expected.
- Added some spock gaurds to prevent tests from running when some
  versions of python aren't avalible on the systems

Fixing #4
