### PR TITLE
Adding docs on pivy-importer and added a way to access required deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,19 @@ The @linkedin/pygradle-devs team feels the major advantages of using PyGradle, a
 
 # Getting Started
 
-*This section will be updated once we release the plugin into gradle's plugin repository.*
-
 For a quick start, lets look at a simple example of publishing a library using two dependencies.
 
-    apply plugin: 'com.linkedin.python-sdist'
+    plugins {
+      id "com.linkedin.python-sdist" version "0.3.6"
+    }
 
     dependencies {
         python 'pypi:requests:2.5.1'
         test 'pypi:mock:1.0.1'
+    }
+    
+    repositories {
+       pyGradlePyPi()
     }
 
 We apply a plugin `com.linkedin.python-sdist` which adds configurations `python` and `test` to the project. In the dependencies section
@@ -57,6 +61,23 @@ There are some cases where you will need to implement a distribution class that 
 a suggested setup.py for projects. You can find it in pygradle-plugin/templates/setup.py.template. In order to make it easy for
 consumers to use, we also provide a task `generateSetupPy` that will write it out to disk. Be careful, this task *will* 
 overwrite any existing setup.py in the project.
+
+## PyPi Artifacts
+
+PyGradle depends on Ivy metadata to build a dependency graph, thus we cannot use pypi directly. We do have a java library that 
+will convert libraries from pypi into Ivy located in pivy-importer. In that project you can find usage examples. The pivy-importer
+project is how the integration tests get their required dependencies.
+
+To help with on boarding, we are providing a repository that has all of pygradle's require dependencies. You can apply it by adding 
+
+    repositories {
+       pyGradlePyPi()
+    }
+
+to your build.gradle. This is not intended to be a full mirror and will never be a full mirror of pypi. It has the dependencies that
+PyGradle requires to start, and may in the future include very common libraries. The repo was seeded using the pivy-importer.
+
+For more details on the pivy-importer please [read the docs](docs/pivy-importer.md).
 
 # Developing on PyGradle
 

--- a/buildSrc/src/main/groovy/com/linkedin/gradle/build/version/VersionBumpTask.groovy
+++ b/buildSrc/src/main/groovy/com/linkedin/gradle/build/version/VersionBumpTask.groovy
@@ -58,7 +58,7 @@ class VersionBumpTask extends DefaultTask {
         } else {
             nextVersion = currentVersion.withNextPatch()
         }
-        
+
         VersionFile.writeVersionToFile(versionFile, nextVersion)
         repo.add(patterns: ['version.properties'])
         repo.commit(

--- a/docs/pivy-importer.md
+++ b/docs/pivy-importer.md
@@ -1,0 +1,18 @@
+# pivy-importer
+
+The pivy-importer is a Java application that can be used to pull libraries from pypi into an Ivy format. It has
+several features that you may find useful in dealing with pypi projects.
+ 
+## General Usage
+
+`java -jar pivy-importer.jar --repo /path/to/destination virtualenv:15.0.1 pip:7.1.2`
+
+For a complete usage example please review the build.gradle file for the pivy-importer project.
+
+## Replacement
+
+In some cases it's useful to replace dependencies with another one to deal with how Pip does dependency resolution. 
+To enable this feature you need to add the option `--replace` followed by a list of arguments in the form 
+oldName:oldVersion=newName:newVersion (`alabaster:0.7=alabaster:0.7.1`). You can provide multiple 
+replacements by joining them with a comma.
+ 

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
@@ -57,4 +57,39 @@ class PythonPluginIntegrationTest extends Specification {
         result.task(':check').outcome == TaskOutcome.SUCCESS
         result.task(':build').outcome == TaskOutcome.SUCCESS
     }
+
+    def "can use external library"() {
+        given:
+        testProjectDir.buildFile << """
+        |plugins {
+        |    id 'com.linkedin.python'
+        |}
+        |
+        |repositories {
+        |   pyGradlePyPi()
+        |}
+        """.stripMargin().stripIndent()
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('build')
+            .withPluginClasspath()
+            .withDebug(true)
+            .build()
+        println result.output
+
+        then:
+
+        result.output.contains("BUILD SUCCESS")
+        result.output.contains('test/test_a.py ..')
+        result.task(':flake8').outcome == TaskOutcome.SUCCESS
+        result.task(':installPythonRequirements').outcome == TaskOutcome.SUCCESS
+        result.task(':installTestRequirements').outcome == TaskOutcome.SUCCESS
+        result.task(':createVirtualEnvironment').outcome == TaskOutcome.SUCCESS
+        result.task(':installProject').outcome == TaskOutcome.SUCCESS
+        result.task(':pytest').outcome == TaskOutcome.SUCCESS
+        result.task(':check').outcome == TaskOutcome.SUCCESS
+        result.task(':build').outcome == TaskOutcome.SUCCESS
+    }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -24,6 +24,8 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.DependencyResolveDetails
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.bundling.Compression
@@ -335,6 +337,24 @@ class PythonPlugin implements Plugin<Project> {
         }
 
         project.tasks.create(TASK_SETUP_PY_WRITER, GenerateSetupPyTask)
+
+        project.getRepositories().metaClass.pyGradlePyPi = { ->
+            delegate.ivy(new Action<IvyArtifactRepository>() {
+                @Override
+                void execute(IvyArtifactRepository ivyArtifactRepository) {
+                    ivyArtifactRepository.setName('pygradle-pypi')
+                    ivyArtifactRepository.setUrl('https://ethankhall.bintray.com/pygradle-pypi/')
+                    ivyArtifactRepository.layout("pattern", new Action<IvyPatternRepositoryLayout>() {
+                        @Override
+                        void execute(IvyPatternRepositoryLayout repositoryLayout) {
+                            repositoryLayout.artifact('[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]')
+                            repositoryLayout.ivy('[organisation]/[module]/[revision]/[module]-[revision].ivy')
+                            repositoryLayout.setM2compatible(true)
+                        }
+                    })
+                }
+            })
+        }
     }
 
     static class PackageDocumentationAction implements Action<Tar> {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/GenerateSetupPyTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/GenerateSetupPyTask.java
@@ -37,7 +37,7 @@ public class GenerateSetupPyTask extends DefaultTask {
     @TaskAction
     public void createSetupPy() throws IOException {
         File file = getProject().file("setup.py");
-        if(file.exists()) {
+        if (file.exists()) {
             logger.lifecycle("Contents of setup.py are going to be overwritten!!");
             file.delete();
         }


### PR DESCRIPTION
This adds a method pyGradlePyPi to the dependencies closure that will
allow people to use pygradle without having to have their own ivy repo
set up that contains all of our dependencies