### PR TITLE
Fixing buildDir and allowing people to add their own version forcing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.logging.configuration.ConsoleOutput
+
 apply plugin: 'version'
 apply plugin: 'idea'
 
@@ -16,6 +18,21 @@ subprojects {
         doLast {
             configurations.each { conf ->
                 conf.files
+            }
+        }
+    }
+
+    tasks.withType(Test) { task ->
+        if (gradle.startParameter.consoleOutput == ConsoleOutput.Plain) {   //on ci we will see tests as they run
+            task.afterTest { TestDescriptor td, TestResult tr ->
+                logger.lifecycle("[${tr.resultType}] - ${td.className}#${td.name}")
+
+            }
+        }
+        task.afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                logger.lifecycle("Task {} results: {} ({} tests, {} successes, {} failures, {} skipped)", task.path,
+                    result.resultType, result.testCount, result.successfulTestCount, result.failedTestCount, result.skippedTestCount)
             }
         }
     }

--- a/codequality/checkstyle/checkstyle.xml
+++ b/codequality/checkstyle/checkstyle.xml
@@ -7,7 +7,7 @@
 LinkedIn Java style.
 -->
 <module name="Checker">
-  <property name="severity" value="warning"/>
+  <property name="severity" value="error"/>
   <property name="fileExtensions" value="java"/>
 
   <module name="TreeWalker">

--- a/pygradle-plugin/build.gradle
+++ b/pygradle-plugin/build.gradle
@@ -53,6 +53,7 @@ licenseReport {
 
 task integTest(type: Test) {
     dependsOn(':pivy-importer:importRequiredDependencies')
+    shouldRunAfter tasks.test
     testClassesDir = sourceSets.integTest.output.classesDir
     classpath = sourceSets.integTest.runtimeClasspath
     reports.html.destination = file("$buildDir/reports/integration-test")

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
@@ -68,6 +68,8 @@ class PythonPluginIntegrationTest extends Specification {
         |repositories {
         |   pyGradlePyPi()
         |}
+        |
+        |buildDir = 'build2'
         """.stripMargin().stripIndent()
 
         when:
@@ -81,6 +83,8 @@ class PythonPluginIntegrationTest extends Specification {
 
         then:
 
+        !new File(testProjectDir.getRoot(), 'build').exists()
+        new File(testProjectDir.getRoot(), 'build2').exists()
         result.output.contains("BUILD SUCCESS")
         result.output.contains('test/test_a.py ..')
         result.task(':flake8').outcome == TaskOutcome.SUCCESS

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -62,7 +62,7 @@ class PythonExtension {
     public ConsoleOutput consoleOutput = ConsoleOutput.ASCII
 
     public PythonExtension(Project project) {
-        this.details = new PythonDetails(project, new File(project.buildDir, "venv"))
+        this.details = new PythonDetails(project)
         docsDir = project.file("${project.projectDir}/docs").path
         testDir = project.file("${project.projectDir}/test").path
         srcDir = project.file("${project.projectDir}/src").path
@@ -70,7 +70,7 @@ class PythonExtension {
         pinnedFile = project.file("pinned.txt")
 
         pythonEnvironment = [
-                'PATH': project.file("${details.virtualEnv.absolutePath}/bin").path + ':' + System.getenv('PATH'),]
+                'PATH': "${-> details.virtualEnv.absolutePath}/bin" + ':' + System.getenv('PATH'),]
 
         pythonEnvironmentDistgradle = ['PYGRADLE_PROJECT_NAME'   : project.name,
                                        'PYGRADLE_PROJECT_VERSION': "${ -> project.version }",]

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -56,6 +56,7 @@ class PythonExtension {
     /** The name of the pinned requirements file. */
     public File pinnedFile
 
+    /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
         'argparse'      : ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '2.5.4'],
@@ -69,7 +70,6 @@ class PythonExtension {
         'setuptools-git': ['group': 'pypi', 'name': 'setuptools-git', 'version': '1.1'],
         'six'           : ['group': 'pypi', 'name': 'six', 'version': '1.10.0'],
         'Sphinx'        : ['group': 'pypi', 'name': 'Sphinx', 'version': '1.4.1'],
-        'unittest2'     : ['group': 'pypi', 'name': 'unittest2', 'version': '1.1.0.1'],
         'virtualenv'    : ['group': 'pypi', 'name': 'virtualenv', 'version': '15.0.1'],
         'wheel'         : ['group': 'pypi', 'name': 'wheel', 'version': '0.26.0'],
     ]

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -56,6 +56,24 @@ class PythonExtension {
     /** The name of the pinned requirements file. */
     public File pinnedFile
 
+    public Map<String, Map<String, String>> forcedVersions = [
+        'argparse'      : ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
+        'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '2.5.4'],
+        'pbr'           : ['group': 'pypi', 'name': 'pbr', 'version': '1.8.0'],
+        'pex'           : ['group': 'pypi', 'name': 'pex', 'version': '1.1.4'],
+        'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '7.1.2'],
+        'pytest'        : ['group': 'pypi', 'name': 'pytest', 'version': '2.9.1'],
+        'pytest-cov'    : ['group': 'pypi', 'name': 'pytest-cov', 'version': '2.2.1'],
+        'pytest-xdist'  : ['group': 'pypi', 'name': 'pytest-xdist', 'version': '1.14'],
+        'setuptools'    : ['group': 'pypi', 'name': 'setuptools', 'version': '19.1.1'],
+        'setuptools-git': ['group': 'pypi', 'name': 'setuptools-git', 'version': '1.1'],
+        'six'           : ['group': 'pypi', 'name': 'six', 'version': '1.10.0'],
+        'Sphinx'        : ['group': 'pypi', 'name': 'Sphinx', 'version': '1.4.1'],
+        'unittest2'     : ['group': 'pypi', 'name': 'unittest2', 'version': '1.1.0.1'],
+        'virtualenv'    : ['group': 'pypi', 'name': 'virtualenv', 'version': '15.0.1'],
+        'wheel'         : ['group': 'pypi', 'name': 'wheel', 'version': '0.26.0'],
+    ]
+
     /* Container of the details related to the venv/python instance */
     private final PythonDetails details
 
@@ -70,7 +88,7 @@ class PythonExtension {
         pinnedFile = project.file("pinned.txt")
 
         pythonEnvironment = [
-                'PATH': "${-> details.virtualEnv.absolutePath}/bin" + ':' + System.getenv('PATH'),]
+                'PATH': "${ -> details.virtualEnv.absolutePath }/bin" + ':' + System.getenv('PATH'),]
 
         pythonEnvironmentDistgradle = ['PYGRADLE_PROJECT_NAME'   : project.name,
                                        'PYGRADLE_PROJECT_VERSION': "${ -> project.version }",]
@@ -87,6 +105,24 @@ class PythonExtension {
         if (pythonEnvironment.containsKey('PYGRADLE_PROJECT_VERSION')) {
             throw new GradleException("Cannot proceed with `PYGRADLE_PROJECT_VERSION` set in environment!")
         }
+    }
+
+    public void forceVersion(String group, String name, String version) {
+        Objects.requireNonNull(group, "Group cannot be null")
+        Objects.requireNonNull(name, "Name cannot be null")
+        Objects.requireNonNull(version, "Version cannot be null")
+        forcedVersions[name] = ['group': group, 'name': name, 'version': version]
+    }
+
+    public void forceVersion(String gav) {
+        Objects.requireNonNull(gav, "GAV cannot be null")
+
+        String[] split = gav.split(':')
+        if (split.length < 3) {
+            throw new GradleException("Unable to parse GAV $gav")
+        }
+
+        forceVersion(split[0], split[1], split[2])
     }
 
     public PythonDetails getDetails() {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
@@ -26,7 +26,6 @@ public class PythonDetails {
 
     private final Project project;
 
-    private final File virtualEnv;
     private File activateLink;
     private File pythonInterpreter;
     private String virtualEnvPrompt;
@@ -34,12 +33,11 @@ public class PythonDetails {
 
     private List<File> searchPath;
 
-    public PythonDetails(Project project, File virtualenvLocation) {
+    public PythonDetails(Project project) {
         this.project = project;
         pythonInterpreter = new File("/usr/bin/python");
         updateFromPythonInterpreter();
 
-        virtualEnv = virtualenvLocation;
         activateLink = new File(project.getProjectDir(), "activate");
         virtualEnvPrompt = String.format("(%s)", project.getName());
         searchPath = ExecutablePathUtils.getPath();
@@ -61,11 +59,11 @@ public class PythonDetails {
     }
 
     public File getVirtualEnv() {
-        return virtualEnv;
+        return new File(project.getBuildDir(), "venv");
     }
 
     public File getVirtualEnvInterpreter() {
-        return new File(virtualEnv, "bin/python");
+        return new File(getVirtualEnv(), "bin/python");
     }
 
     public File getSystemPythonInterpreter() {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PyGradleDependencyResolveDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PyGradleDependencyResolveDetails.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.plugin;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependencyResolveDetails;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import java.util.Map;
+import java.util.Objects;
+
+
+public class PyGradleDependencyResolveDetails implements Action<DependencyResolveDetails> {
+
+    private static final Logger LOGGER = Logging.getLogger(PyGradleDependencyResolveDetails.class);
+
+    private final Map<String, Map<String, String>> requiredVersions;
+
+    public PyGradleDependencyResolveDetails(Map<String, Map<String, String>> requiredVersions) {
+        this.requiredVersions = requiredVersions;
+    }
+
+    @Override
+    public void execute(DependencyResolveDetails details) {
+        if (requiredVersions.containsKey(details.getRequested().getName())) {
+            String name = details.getRequested().getName();
+            String version = requiredVersions.get(name).get("version");
+            if (Objects.equals("", version) || null == version) {
+                return;
+            }
+            LOGGER.info("Resolving {} to {}=={} per gradle-python resolution strategy.", name, name, version);
+            details.useVersion(version);
+        }
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonFlyerPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonFlyerPlugin.groovy
@@ -82,7 +82,7 @@ class PythonFlyerPlugin implements Plugin<Project> {
             task.doLast {
                 if (!project.file("${project.projectDir}/resource").exists()) {
                     println "Making the Symlink: ${project.projectDir}/resource --> ${resourceConf.singleFile}"
-                    FileSystemUtils.makeSymLink(project, resourceConf.singleFile, new File(project.projectDir, 'resource'))
+                    FileSystemUtils.makeSymLink(resourceConf.singleFile, new File(project.projectDir, 'resource'))
                 }
             }
         }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPexDistributionPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPexDistributionPlugin.groovy
@@ -34,6 +34,7 @@ class PythonPexDistributionPlugin extends PythonBasePlugin {
     void applyTo(Project project) {
 
         project.plugins.apply(PythonPlugin)
+        def extension = ExtensionUtils.getPythonExtension(project)
         ExtensionUtils.maybeCreatePexExtension(project)
         ExtensionUtils.maybeCreateWheelExtension(project)
         DeployableExtension deployableExtension = ExtensionUtils.maybeCreateDeployableExtension(project)
@@ -41,11 +42,10 @@ class PythonPexDistributionPlugin extends PythonBasePlugin {
 
         project.afterEvaluate {
             if (settings.details.pythonVersion.pythonMajorMinor == '2.6') {
-                project.dependencies.add(PythonPlugin.CONFIGURATION_BUILD_REQS,
-                        PythonPlugin.PINNED_VERSIONS['argparse'])
+                project.dependencies.add(PythonPlugin.CONFIGURATION_BUILD_REQS, extension.forcedVersions['argparse'])
             }
         }
-        project.dependencies.add(PythonPlugin.CONFIGURATION_BUILD_REQS, PythonPlugin.PINNED_VERSIONS['pex'])
+        project.dependencies.add(PythonPlugin.CONFIGURATION_BUILD_REQS, extension.forcedVersions['pex'])
 
 
         /**

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -165,9 +165,6 @@ class PythonPlugin implements Plugin<Project> {
             doLast {
                 def activateLinkSource = VirtualEnvExecutableHelper.getExecutable(settings, "bin/activate")
                 def activateLink = settings.getDetails().activateLink
-                if (activateLink.exists()) {
-                    activateLink.delete()
-                }
                 FileSystemUtils.makeSymLink(activateLinkSource, activateLink)
             }
         }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -189,7 +189,11 @@ class PythonPlugin implements Plugin<Project> {
 
             doLast {
                 def activateLinkSource = VirtualEnvExecutableHelper.getExecutable(settings, "bin/activate")
-                FileSystemUtils.makeSymLink(project, activateLinkSource, settings.getDetails().activateLink)
+                def activateLink = settings.getDetails().activateLink
+                if (activateLink.exists()) {
+                    activateLink.delete()
+                }
+                FileSystemUtils.makeSymLink(activateLinkSource, activateLink)
             }
         }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
@@ -32,12 +32,12 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
     boolean specificFileGiven = false
 
     PyTestTask() {
-        args(VirtualEnvExecutableHelper.findExecutable(component, "bin/py.test").absolutePath)
         ignoreExitValue = true
     }
 
     @Override
     public void preExecution() {
+        args(VirtualEnvExecutableHelper.findExecutable(component, "bin/py.test").absolutePath)
         if (!specificFileGiven) {
             args(component.testDir)
         }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/FileSystemUtils.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/FileSystemUtils.java
@@ -40,7 +40,8 @@ public class FileSystemUtils {
          * Check if the file exists because the link checking logic in Gradle differs
          * between Linux and OS X machines.
          */
-        Files.deleteIfExists(destination.toPath());
-        Files.createSymbolicLink(destination.toPath(), target.toPath());
+        if (!Files.exists(destination.toPath())) {
+            Files.createSymbolicLink(destination.toPath(), target.toPath());
+        }
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/FileSystemUtils.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/FileSystemUtils.java
@@ -16,8 +16,6 @@
 
 package com.linkedin.gradle.python.util;
 
-import org.gradle.api.Project;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,18 +31,16 @@ public class FileSystemUtils {
      * <p>
      * Make a link using the system's ``ln`` command.
      * <p>
-     * @param project The project to run within.
      * @param target The target directory that the link points to.
      * @param destination The destination directory or the name of the link.
      * @throws IOException if symlink can't be made
      */
-    public static void makeSymLink(Project project, File target, File destination) throws IOException {
+    public static void makeSymLink(File target, File destination) throws IOException {
         /*
          * Check if the file exists because the link checking logic in Gradle differs
          * between Linux and OS X machines.
          */
-        if (!project.file(destination).exists()) {
-            Files.createSymbolicLink(destination.toPath(), target.toPath());
-        }
+        Files.deleteIfExists(destination.toPath());
+        Files.createSymbolicLink(destination.toPath(), target.toPath());
     }
 }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/TestPythonExtension.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/TestPythonExtension.groovy
@@ -34,4 +34,52 @@ class TestPythonExtension extends Specification {
         parts.contains('/usr/bin')
     }
 
+    def 'can add new values to forced versions'() {
+        def settings = new PythonExtension(project)
+
+        when:
+        settings.forceVersion('a', 'b', 'c')
+
+        then:
+        settings.forcedVersions['b'] == ['group': 'a', 'name': 'b', 'version': 'c']
+
+        when:
+        settings.forceVersion('a:b:f')
+
+        then:
+        settings.forcedVersions['b'] == ['group': 'a', 'name': 'b', 'version': 'f']
+    }
+
+    def 'will throw if any value is null'() {
+        def settings = new PythonExtension(project)
+
+        when:
+        settings.forceVersion(null, 'b', 'c')
+
+        then:
+        def ex = thrown(NullPointerException)
+        ex.message == 'Group cannot be null'
+
+        when:
+        settings.forceVersion('a', null, 'c')
+
+        then:
+        ex = thrown(NullPointerException)
+        ex.message == 'Name cannot be null'
+
+        when:
+        settings.forceVersion('a', 'b', null)
+
+        then:
+        ex = thrown(NullPointerException)
+        ex.message == 'Version cannot be null'
+
+        when:
+        settings.forceVersion(null)
+
+        then:
+        ex = thrown(NullPointerException)
+        ex.message == 'GAV cannot be null'
+    }
+
 }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDetailsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDetailsTest.groovy
@@ -27,7 +27,7 @@ class PythonDetailsTest extends Specification {
     @Rule
     TemporaryFolder temporaryFolder
     def project = new ProjectBuilder().build()
-    def settings = new PythonDetails(project, null)
+    def settings = new PythonDetails(project)
 
     def "interpreterPath without interpreterVersion"() {
         expect: "default system Python without any settings"


### PR DESCRIPTION
With the buildDir change pygradle will respect what users set to be their buildDir for the project. Before it would not honor it for everything.

With the pinned dependency update users can how override our default values or add their own so they can pick build libraries that are used.