### PR TITLE
Cannot set `details` block in `build.gradle`

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/DefaultProjectLayoutRule.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/DefaultProjectLayoutRule.groovy
@@ -40,12 +40,15 @@ class DefaultProjectLayoutRule extends TemporaryFolder {
         // Create some code
         newFile('src/foo/__init__.py')
         newFile('src/foo/hello.py') << '''\
+        | from __future__ import print_function
+        |
+        |
         | def generate_welcome():
         |     return 'Hello World'
         |
         |
         | def main():
-        |     print generate_welcome()
+        |     print(generate_welcome())
         |'''.stripMargin().stripIndent()
 
         // set up the default project name

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
@@ -96,4 +96,43 @@ class PythonPluginIntegrationTest extends Specification {
         result.task(':check').outcome == TaskOutcome.SUCCESS
         result.task(':build').outcome == TaskOutcome.SUCCESS
     }
+
+    def "can build v3 library"() {
+        given:
+        testProjectDir.buildFile << """
+        |plugins {
+        |    id 'com.linkedin.python'
+        |}
+        |
+        |python {
+        | details {
+        |   pythonVersion = 3.5
+        | }
+        |}
+        |
+        |${PyGradleTestBuilder.createRepoClosure()}
+        """.stripMargin().stripIndent()
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('build')
+                .withPluginClasspath()
+                .withDebug(true)
+                .build()
+        println result.output
+
+        then:
+
+        result.output.contains("BUILD SUCCESS")
+        result.output.contains('test/test_a.py .')
+        result.task(':flake8').outcome == TaskOutcome.SUCCESS
+        result.task(':installPythonRequirements').outcome == TaskOutcome.SUCCESS
+        result.task(':installTestRequirements').outcome == TaskOutcome.SUCCESS
+        result.task(':createVirtualEnvironment').outcome == TaskOutcome.SUCCESS
+        result.task(':installProject').outcome == TaskOutcome.SUCCESS
+        result.task(':pytest').outcome == TaskOutcome.SUCCESS
+        result.task(':check').outcome == TaskOutcome.SUCCESS
+        result.task(':build').outcome == TaskOutcome.SUCCESS
+    }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -31,6 +31,9 @@ class PythonExtension {
     /** The environment to use for all Python commands. */
     public Map<String, Object> pythonEnvironment
 
+    /** This gradle project */
+    private final Project project
+
     /**
      * The environment to use for Python commands run on the project being
      * developed.
@@ -81,6 +84,7 @@ class PythonExtension {
 
     public PythonExtension(Project project) {
         this.details = new PythonDetails(project)
+        this.project = project
         docsDir = project.file("${project.projectDir}/docs").path
         testDir = project.file("${project.projectDir}/test").path
         srcDir = project.file("${project.projectDir}/src").path
@@ -127,6 +131,10 @@ class PythonExtension {
 
     public PythonDetails getDetails() {
         return details
+    }
+
+    public void details(Closure cl) {
+        project.configure(details, cl)
     }
 
     public Map<String, Object> getEnvironment() {


### PR DESCRIPTION
When setting the `details` block in your `build.gradle`, gradle yields the following when trying to build your project.

```
FAILURE: Build failed with an exception.

* Where:
Build file '/tmp/junit3053109164895062324/build.gradle' line: 7

* What went wrong:
A problem occurred evaluating root project 'junit3053109164895062324'.
> Could not find method details() for arguments [build_4vooep3cvvjfq4yfrz6qrhcgl$_run_closure1$_closure3@68f7c8eb] on root project 'junit3053109164895062324'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 0.152 secs

	at org.gradle.testkit.runner.internal.DefaultGradleRunner$1.execute(DefaultGradleRunner.java:222)
	at org.gradle.testkit.runner.internal.DefaultGradleRunner$1.execute(DefaultGradleRunner.java:219)
	at org.gradle.testkit.runner.internal.DefaultGradleRunner.run(DefaultGradleRunner.java:282)
	at org.gradle.testkit.runner.internal.DefaultGradleRunner.build(DefaultGradleRunner.java:219)
	at com.linkedin.gradle.python.plugin.PythonPluginIntegrationTestv3.can build library(PythonPluginIntegrationTestv3.groovy:67)
```

I've attached a PR with an integration test to demonstrate the failure.