### PR TITLE
Changing url to https://linkedin.jfrog.io/linkedin/pypi-external/

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -319,7 +319,7 @@ class PythonPlugin implements Plugin<Project> {
                 @Override
                 void execute(IvyArtifactRepository ivyArtifactRepository) {
                     ivyArtifactRepository.setName('pygradle-pypi')
-                    ivyArtifactRepository.setUrl('https://ethankhall.bintray.com/pygradle-pypi/')
+                    ivyArtifactRepository.setUrl('https://linkedin.jfrog.io/linkedin/pypi-external/')
                     ivyArtifactRepository.layout("pattern", new Action<IvyPatternRepositoryLayout>() {
                         @Override
                         void execute(IvyPatternRepositoryLayout repositoryLayout) {


### PR DESCRIPTION
Bintray is going to delete the repo I set up because of a trial. So
instead of just moving it to a different name quickly lets make it a
good solution that will scale.