### PR TITLE
Fixing dsl for python.details {}

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/DefaultProjectLayoutRule.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/DefaultProjectLayoutRule.groovy
@@ -40,12 +40,15 @@ class DefaultProjectLayoutRule extends TemporaryFolder {
         // Create some code
         newFile('src/foo/__init__.py')
         newFile('src/foo/hello.py') << '''\
+        | from __future__ import print_function
+        |
+        |
         | def generate_welcome():
         |     return 'Hello World'
         |
         |
         | def main():
-        |     print generate_welcome()
+        |     print(generate_welcome())
         |'''.stripMargin().stripIndent()
 
         // set up the default project name

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
@@ -69,6 +69,12 @@ class PythonPluginIntegrationTest extends Specification {
         |   pyGradlePyPi()
         |}
         |
+        |python {
+        |   details {
+        |       virtualEnvPrompt = 'pyGradle!'
+        |   }
+        |}
+        |
         |buildDir = 'build2'
         """.stripMargin().stripIndent()
 
@@ -87,45 +93,6 @@ class PythonPluginIntegrationTest extends Specification {
         new File(testProjectDir.getRoot(), 'build2').exists()
         result.output.contains("BUILD SUCCESS")
         result.output.contains('test/test_a.py ..')
-        result.task(':flake8').outcome == TaskOutcome.SUCCESS
-        result.task(':installPythonRequirements').outcome == TaskOutcome.SUCCESS
-        result.task(':installTestRequirements').outcome == TaskOutcome.SUCCESS
-        result.task(':createVirtualEnvironment').outcome == TaskOutcome.SUCCESS
-        result.task(':installProject').outcome == TaskOutcome.SUCCESS
-        result.task(':pytest').outcome == TaskOutcome.SUCCESS
-        result.task(':check').outcome == TaskOutcome.SUCCESS
-        result.task(':build').outcome == TaskOutcome.SUCCESS
-    }
-
-    def "can build v3 library"() {
-        given:
-        testProjectDir.buildFile << """
-        |plugins {
-        |    id 'com.linkedin.python'
-        |}
-        |
-        |python {
-        | details {
-        |   pythonVersion = 3.5
-        | }
-        |}
-        |
-        |${PyGradleTestBuilder.createRepoClosure()}
-        """.stripMargin().stripIndent()
-
-        when:
-        def result = GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
-                .withArguments('build')
-                .withPluginClasspath()
-                .withDebug(true)
-                .build()
-        println result.output
-
-        then:
-
-        result.output.contains("BUILD SUCCESS")
-        result.output.contains('test/test_a.py .')
         result.task(':flake8').outcome == TaskOutcome.SUCCESS
         result.task(':installPythonRequirements').outcome == TaskOutcome.SUCCESS
         result.task(':installTestRequirements').outcome == TaskOutcome.SUCCESS

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
@@ -96,4 +96,43 @@ class PythonPluginIntegrationTest extends Specification {
         result.task(':check').outcome == TaskOutcome.SUCCESS
         result.task(':build').outcome == TaskOutcome.SUCCESS
     }
+
+    def "can build v3 library"() {
+        given:
+        testProjectDir.buildFile << """
+        |plugins {
+        |    id 'com.linkedin.python'
+        |}
+        |
+        |python {
+        | details {
+        |   pythonVersion = 3.5
+        | }
+        |}
+        |
+        |${PyGradleTestBuilder.createRepoClosure()}
+        """.stripMargin().stripIndent()
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('build')
+                .withPluginClasspath()
+                .withDebug(true)
+                .build()
+        println result.output
+
+        then:
+
+        result.output.contains("BUILD SUCCESS")
+        result.output.contains('test/test_a.py .')
+        result.task(':flake8').outcome == TaskOutcome.SUCCESS
+        result.task(':installPythonRequirements').outcome == TaskOutcome.SUCCESS
+        result.task(':installTestRequirements').outcome == TaskOutcome.SUCCESS
+        result.task(':createVirtualEnvironment').outcome == TaskOutcome.SUCCESS
+        result.task(':installProject').outcome == TaskOutcome.SUCCESS
+        result.task(':pytest').outcome == TaskOutcome.SUCCESS
+        result.task(':check').outcome == TaskOutcome.SUCCESS
+        result.task(':build').outcome == TaskOutcome.SUCCESS
+    }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -31,9 +31,6 @@ class PythonExtension {
     /** The environment to use for all Python commands. */
     public Map<String, Object> pythonEnvironment
 
-    /** This gradle project */
-    private final Project project
-
     /**
      * The environment to use for Python commands run on the project being
      * developed.
@@ -84,7 +81,6 @@ class PythonExtension {
 
     public PythonExtension(Project project) {
         this.details = new PythonDetails(project)
-        this.project = project
         docsDir = project.file("${project.projectDir}/docs").path
         testDir = project.file("${project.projectDir}/test").path
         srcDir = project.file("${project.projectDir}/src").path
@@ -133,8 +129,15 @@ class PythonExtension {
         return details
     }
 
-    public void details(Closure cl) {
-        project.configure(details, cl)
+    /**
+     * Configures the {@link PythonDetails} for the project.
+     *
+     * @param a {@link Closure} that will delegate to {@link PythonDetails}
+     */
+    public void details(@DelegatesTo(PythonDetails) Closure cl) {
+        cl.delegate = details
+        cl.resolveStrategy = Closure.DELEGATE_FIRST
+        cl.call()
     }
 
     public Map<String, Object> getEnvironment() {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -31,6 +31,9 @@ class PythonExtension {
     /** The environment to use for all Python commands. */
     public Map<String, Object> pythonEnvironment
 
+    /** This gradle project */
+    private final Project project
+
     /**
      * The environment to use for Python commands run on the project being
      * developed.
@@ -81,6 +84,7 @@ class PythonExtension {
 
     public PythonExtension(Project project) {
         this.details = new PythonDetails(project)
+        this.project = project
         docsDir = project.file("${project.projectDir}/docs").path
         testDir = project.file("${project.projectDir}/test").path
         srcDir = project.file("${project.projectDir}/src").path
@@ -127,6 +131,10 @@ class PythonExtension {
 
     public PythonDetails getDetails() {
         return details
+    }
+
+    public void details(Closure cl) {
+        project.configure(details, cl)
     }
 
     public Map<String, Object> getEnvironment() {

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/TestPythonExtension.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/TestPythonExtension.groovy
@@ -82,4 +82,16 @@ class TestPythonExtension extends Specification {
         ex.message == 'GAV cannot be null'
     }
 
+    def 'will work with closure to configure python details'() {
+        def settings = new PythonExtension(project)
+
+        when:
+        settings.details {
+            virtualEnvPrompt = 'hello!'
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
 }


### PR DESCRIPTION
Moving from using project to setting the deletage on the closure

This should also make sure that if people have pygradle loaded their
groovy IDE should be able to let you know what the options are for the
closure.

This removes an integ test and adds a unit test. The integ test sets a
value to make sure the parse works, but doesn't require another test
(which adds a bunch of time to builds)

This fixes the issues in #31 and supersedes it.