### PR TITLE
Fixing spelling and pip install wierdness

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'maven-publish'
+apply plugin: 'ivy-publish'
 apply plugin: 'com.jfrog.artifactory'
 
 task sourceJar(type: Jar) {
@@ -42,6 +43,19 @@ publishing {
                 }
             }
         }
+        ivyJava(IvyPublication) {
+          from components.java
+        }
+    }
+    repositories {
+      ivy {
+        url "${System.getProperty("user.home")}/local-repo"
+        layout('pattern') {
+          ivy "[organisation]/[module]/[revision]/[module]-[revision].ivy"
+          artifact "[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
+          m2compatible true
+        }
+      }
     }
 }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -92,12 +92,14 @@ class BuildWheelsTask extends DefaultTask {
 
             def shortHand = packageInfo.version ? "${packageInfo.name}-${packageInfo.version}" : packageInfo.name
 
+            def messageHead = 'Preparing wheel ' + shortHand
+
             if (tree.files.size() >= 1) {
-                LOGGER.lifecycle(PythonHelpers.createPrettyLine("Prepairing wheel ${shortHand}", "[SKIPPING]"))
+                LOGGER.lifecycle(PythonHelpers.createPrettyLine(messageHead, "[SKIPPING]"))
                 return
             }
 
-            LOGGER.lifecycle(PythonHelpers.createPrettyLine("Prepairing wheel ${shortHand}", "[STARTING]"))
+            LOGGER.lifecycle(PythonHelpers.createPrettyLine(messageHead, "[STARTING]"))
 
             def startTime = LocalDateTime.now()
             ExecResult installResult = project.exec { ExecSpec execSpec ->
@@ -125,7 +127,7 @@ class BuildWheelsTask extends DefaultTask {
                 if (settings.consoleOutput == ConsoleOutput.RAW) {
                     LOGGER.lifecycle(stream.toString().trim())
                 } else {
-                    String prefix = String.format("Preparing wheel %s (%d:%02d s)", shortHand, duration.toMinutes(), duration.getSeconds() % 60)
+                    String prefix = String.format(messageHead + ' (%d:%02d s)', duration.toMinutes(), duration.getSeconds() % 60)
                     LOGGER.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -91,7 +91,6 @@ class PipInstallTask extends DefaultTask {
             if (environment != null) {
                 mergedEnv.putAll(environment)
             }
-            mergedEnv.putAll(settings.pythonEnvironmentDistgradle)
 
             def commandLine = [VirtualEnvExecutableHelper.getPythonInterpreter(settings),
                                VirtualEnvExecutableHelper.getPip(settings),


### PR DESCRIPTION
Was looking at a build log and realized there was a typo:

```
Prepairing wheel futures-3.0.1 ...................................... [STARTING]
Preparing wheel futures-3.0.1 (0:01 s) .............................. [FINISHED]
Prepairing wheel gunicorn-19.3.0 .................................... [STARTING]
Preparing wheel gunicorn-19.3.0 (0:01 s) ............................ [FINISHED]
Prepairing wheel ipaddress-1.0.16 ................................... [STARTING]
```

This change also fixes where when the project installs other projects built by pygradle using the PYGRADLE_NAME and PYGRADLE_VERSION settings they will override what the project wants to use and causes weird install issues.