### PR TITLE
Adding better support for thin pex templates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ artifactory {
 
         defaults {
             publications ('standardjava')
-            publishIvy = false
         }
     }
     clientConfig.setIncludeEnvVars(false)

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/ExtensionUtils.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/ExtensionUtils.java
@@ -30,9 +30,13 @@ public class ExtensionUtils {
         //private constructor for util class
     }
 
-    private static <T> T maybeCreate(Project project, String name, Class<T> type, Object... args) {
-        PythonExtension component = getPythonExtension(project);
-        ExtensionContainer extensionContainer = ((ExtensionAware) component).getExtensions();
+    public static <T> T maybeCreate(Project project, String name, Class<T> type, Object... args) {
+        PythonExtension extension = getPythonExtension(project);
+        return maybeCreate(extension, name, type, args);
+    }
+
+    public static <T> T maybeCreate(PythonExtension extension, String name, Class<T> type, Object... args) {
+        ExtensionContainer extensionContainer = ((ExtensionAware) extension).getExtensions();
 
         T maybeExtension = extensionContainer.findByType(type);
         if (maybeExtension == null) {
@@ -58,14 +62,22 @@ public class ExtensionUtils {
     }
 
     public static <T> T getPythonComponentExtension(Project project, Class<T> type) {
-        PythonExtension component = getPythonExtension(project);
-        ExtensionContainer extensionContainer = ((ExtensionAware) component).getExtensions();
+        PythonExtension extension = getPythonExtension(project);
+        return getPythonComponentExtension(extension, type);
+    }
+
+    public static <T> T getPythonComponentExtension(PythonExtension extension, Class<T> type) {
+        ExtensionContainer extensionContainer = ((ExtensionAware) extension).getExtensions();
         return extensionContainer.getByType(type);
     }
 
     public static <T> T findPythonComponentExtension(Project project, Class<T> type) {
-        PythonExtension component = getPythonExtension(project);
-        ExtensionContainer extensionContainer = ((ExtensionAware) component).getExtensions();
+        PythonExtension extension = getPythonExtension(project);
+        return findPythonComponentExtension(extension, type);
+    }
+
+    public static <T> T findPythonComponentExtension(PythonExtension extension, Class<T> type) {
+        ExtensionContainer extensionContainer = ((ExtensionAware) extension).getExtensions();
         return extensionContainer.findByType(type);
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/DefaultTemplateProviderOptions.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/DefaultTemplateProviderOptions.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.util.internal.pex;
+
+import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.util.pex.TemplateProviderOptions;
+import org.gradle.api.Project;
+
+/**
+ * Provides some values to help pick which template to use
+ */
+public class DefaultTemplateProviderOptions implements TemplateProviderOptions {
+    private final Project project;
+    private final PythonExtension extension;
+    private final String entryPoint;
+
+    public DefaultTemplateProviderOptions(Project project, PythonExtension extension, String entryPoint) {
+        this.project = project;
+        this.extension = extension;
+        this.entryPoint = entryPoint;
+    }
+
+    @Override public Project getProject() {
+        return project;
+    }
+
+    @Override public PythonExtension getExtension() {
+        return extension;
+    }
+
+    @Override public String getEntryPoint() {
+        return entryPoint;
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pex/DefaultEntryPointTemplateProvider.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pex/DefaultEntryPointTemplateProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.util.pex;
+
+import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.extension.CliExtension;
+import com.linkedin.gradle.python.extension.PexExtension;
+import com.linkedin.gradle.python.util.ExtensionUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+
+public class DefaultEntryPointTemplateProvider implements EntryPointTemplateProvider {
+
+    @Override
+    public String retrieveTemplate(TemplateProviderOptions options) throws IOException {
+        PythonExtension extension = options.getExtension();
+        PexExtension pexExtension = ExtensionUtils.getPythonComponentExtension(extension, PexExtension.class);
+        CliExtension cliExtension = ExtensionUtils.findPythonComponentExtension(extension, CliExtension.class);
+        if (cliExtension != null && pexExtension.isPythonWrapper()) {
+            return IOUtils.toString(DefaultEntryPointTemplateProvider.class.getResourceAsStream("/templates/pex_cli_entrypoint.py.template"));
+        } else {
+            return IOUtils.toString(DefaultEntryPointTemplateProvider.class.getResourceAsStream("/templates/pex_non_cli_entrypoint.sh.template"));
+        }
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pex/EntryPointTemplateProvider.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pex/EntryPointTemplateProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.util.pex;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Used to get a template to use for the entry points
+ */
+public interface EntryPointTemplateProvider extends Serializable {
+
+    /**
+     * Returns a template to be used for an entry point. The template must be renderable by
+     * {@link groovy.text.SimpleTemplateEngine}.
+     *
+     * @param options to use to pick the template
+     * @return A template to be used when building entry points.
+     */
+    String retrieveTemplate(TemplateProviderOptions options) throws IOException;
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pex/TemplateProviderOptions.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pex/TemplateProviderOptions.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.util.pex;
+
+import com.linkedin.gradle.python.PythonExtension;
+import org.gradle.api.Project;
+
+public interface TemplateProviderOptions {
+    Project getProject();
+
+    PythonExtension getExtension();
+
+    String getEntryPoint();
+}


### PR DESCRIPTION
Before we would only accept a string, but that's not useful if someone
needs to pick different options. This way the plugin will now use the
same thing that a user might want to change it to. Also since it's a SAM
it's easy to write a closure for it.