### PR TITLE
Porting features from internal divergence into open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ publish a version until we can validate the changes internally.
 was merged into pip master that fixes the issue (https://github.com/pypa/pip/pull/3701), a version of pip with the fix in it
 has not been released yet. If this is an issue for your org, you could release a version of pip with this fix in it. For
 more details on the change and issues please review https://github.com/pypa/pip/pull/3701 and https://github.com/pypa/pip/pull/3079
+

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ subprojects {
         }
     }
 
+    tasks.matching { it instanceof JavaCompile || it instanceof GroovyCompile }.all {
+        it.options.compilerArgs +=  ['-Xlint:deprecation']
+    }
+
     idea {
         module {
             excludeDirs += buildDir
@@ -51,7 +55,7 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_1_7
 
     afterEvaluate {
-        project.tasks.withType(org.gradle.api.plugins.quality.FindBugs)
+        project.tasks.withType(FindBugs)
             .matching { it.name != 'findbugsMain' }
             .each { it.enabled = false }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ allprojects {
     group = 'com.linkedin.pygradle'
 }
 
+ext {
+    startTime = System.currentTimeMillis()
+}
+
 subprojects {
     apply plugin: 'idea'
     apply plugin: 'java'

--- a/buildSrc/src/main/groovy/com/linkedin/gradle/build/version/Version.java
+++ b/buildSrc/src/main/groovy/com/linkedin/gradle/build/version/Version.java
@@ -81,4 +81,8 @@ public class Version {
     public boolean isSnapshot() {
         return snapshot;
     }
+
+    public String withBuildNumber(Long buildNumber) {
+        return String.format("%d.%d.%d.%d-SNAPSHOT", major, minor, patch, buildNumber);
+    }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -44,7 +44,11 @@ publishing {
             }
         }
         ivyJava(IvyPublication) {
-          from components.java
+            if (project.version.isSnapshot() && project.hasProperty('enableLongVersion')) {
+                revision = project.version.withBuildNumber(startTime)
+                println("Testing Version : " + revision)
+            }
+            from components.java
         }
     }
     repositories {

--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -36,7 +36,8 @@ task importRequiredDependencies(type: JavaExec) { task ->
     main = 'com.linkedin.python.importer.ImporterCLI'
 
     def replacements = ['alabaster:0.7=alabaster:0.7.1', 'pytz:0a=pytz:2016.4', 'Babel:0.8=Babel:1.0',
-                        'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1'].join(",")
+                        'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1', 'chardet:2.2=chardet:2.3.0',
+                        'setuptools:0.6a2=setuptools:19.1.1'].join(",")
     def packagesToInclude = ['virtualenv:15.0.1', 'pip:7.1.2', 'setuptools:19.1.1', 'setuptools-git:1.1',
                              'flake8:2.4.0', 'flake8:2.5.4', 'pytest:2.9.1', 'pytest-cov:2.2.1', 'pytest-xdist:1.14',
                              'wheel:0.26.0', 'pbr:1.8.0', 'Sphinx:1.4.1', 'six:1.10.0', 'pex:1.1.4',

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
@@ -19,10 +19,11 @@ import com.linkedin.gradle.python.util.internal.ExecutablePathUtils;
 import org.gradle.api.Project;
 
 import java.io.File;
+import java.io.Serializable;
 import java.util.List;
 
 
-public class PythonDetails {
+public class PythonDetails implements Serializable {
 
     private final Project project;
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
@@ -27,6 +27,7 @@ public class PythonDetails implements Serializable {
 
     private final Project project;
 
+    private final File venvOverride;
     private File activateLink;
     private File pythonInterpreter;
     private String virtualEnvPrompt;
@@ -35,6 +36,10 @@ public class PythonDetails implements Serializable {
     private List<File> searchPath;
 
     public PythonDetails(Project project) {
+        this(project, null);
+    }
+
+    public PythonDetails(Project project, File venvDir) {
         this.project = project;
         pythonInterpreter = new File("/usr/bin/python");
         updateFromPythonInterpreter();
@@ -42,6 +47,7 @@ public class PythonDetails implements Serializable {
         activateLink = new File(project.getProjectDir(), "activate");
         virtualEnvPrompt = String.format("(%s)", project.getName());
         searchPath = ExecutablePathUtils.getPath();
+        venvOverride = venvDir;
     }
 
     private void updateFromPythonInterpreter() {
@@ -60,7 +66,11 @@ public class PythonDetails implements Serializable {
     }
 
     public File getVirtualEnv() {
-        return new File(project.getBuildDir(), "venv");
+        if (null == venvOverride) {
+            return new File(project.getBuildDir(), "venv");
+        } else {
+            return venvOverride;
+        }
     }
 
     public File getVirtualEnvInterpreter() {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonVersion.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonVersion.java
@@ -15,7 +15,9 @@
  */
 package com.linkedin.gradle.python.extension;
 
-public class PythonVersion {
+import java.io.Serializable;
+
+public class PythonVersion implements Serializable {
 
     private final String version;
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonFlyerPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonFlyerPlugin.groovy
@@ -96,10 +96,6 @@ class PythonFlyerPlugin implements Plugin<Project> {
          */
         project.tasks.create(name: TASK_PACKAGE_RESOURCE_FILES, type: Copy) { Copy copy ->
             def deployableExtension = ExtensionUtils.maybeCreateDeployableExtension(project)
-
-            copy.inputs.dir(resourceConf)
-            copy.outputs.dir("${deployableExtension.deployableBuildDir}/resource")
-
             copy.dependsOn(project.tasks['buildWebApplication'])
 
             copy.from resourceConf

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -150,6 +150,7 @@ class PythonPlugin implements Plugin<Project> {
          */
         project.tasks.create(TASK_VENV_CREATE, InstallVirtualEnvironmentTask) { task ->
             task.dependsOn pinRequirementsTask
+            task.pythonDetails = settings.details
         }
 
         /**

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -176,6 +176,7 @@ class PythonPlugin implements Plugin<Project> {
          * They need to be installed in a specific order. Hence, we set sorted to false here.
          */
         project.tasks.create(TASK_INSTALL_SETUP_REQS, PipInstallTask) {
+            pythonDetails = settings.details
             dependsOn project.tasks.getByName(TASK_SETUP_LINKS)
             args = ['--upgrade']
             installFileCollection = project.configurations.setupRequires
@@ -188,6 +189,7 @@ class PythonPlugin implements Plugin<Project> {
          * The build requirements are the packages we need to run all stages of the build for this product.
          */
         project.tasks.create(TASK_INSTALL_BUILD_REQS, PipInstallTask) {
+            pythonDetails = settings.details
             dependsOn project.tasks.getByName(TASK_INSTALL_SETUP_REQS)
             args = ['--upgrade']
             installFileCollection = project.configurations.build
@@ -200,6 +202,7 @@ class PythonPlugin implements Plugin<Project> {
          *
          */
         project.tasks.create(TASK_INSTALL_PYTHON_REQS, PipInstallTask) {
+            pythonDetails = settings.details
             dependsOn project.tasks.getByName(TASK_INSTALL_BUILD_REQS)
             installFileCollection = project.configurations.python
         }
@@ -210,6 +213,7 @@ class PythonPlugin implements Plugin<Project> {
          * A products test requirements are those that are listed in the ``test`` configuration and are only required for running tests.
          */
         project.tasks.create(TASK_INSTALL_TEST_REQS, PipInstallTask) {
+            pythonDetails = settings.details
             dependsOn project.tasks.getByName(TASK_INSTALL_PYTHON_REQS)
             installFileCollection = project.configurations.test
         }
@@ -220,6 +224,7 @@ class PythonPlugin implements Plugin<Project> {
          * This installs the product itself in editable mode. It is equivalent to running ``python setup.py develop`` on a Python product.
          */
         project.tasks.create(TASK_INSTALL_PROJECT, PipInstallTask) {
+            pythonDetails = settings.details
             dependsOn project.tasks.getByName(TASK_INSTALL_TEST_REQS)
             installFileCollection = project.files(project.file(project.projectDir))
             args = ['--editable']

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -126,7 +126,7 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
                 execSpec.args(additionalArguments);
                 execSpec.setIgnoreExitValue(ignoreExitValue);
 
-                container.execute(execSpec);
+                container.setOutputs(execSpec);
 
                 configureExecution(execSpec);
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -16,6 +16,7 @@
 package com.linkedin.gradle.python.tasks;
 
 import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.extension.PythonDetails;
 import com.linkedin.gradle.python.util.VirtualEnvExecutableHelper;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
@@ -72,9 +73,20 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask {
         return component;
     }
 
+    public PythonDetails getPythonDetails() {
+        if (null == pythonDetails) {
+            pythonDetails = getComponent().getDetails();
+        }
+        return pythonDetails;
+    }
+
+    public void setPythonDetails(PythonDetails pythonDetails) {
+        this.pythonDetails = pythonDetails;
+    }
+
     @InputDirectory
     public FileTree getVirtualEnv() {
-        ConfigurableFileTree files = getProject().fileTree(getComponent().getDetails().getVirtualEnv());
+        ConfigurableFileTree files = getProject().fileTree(getPythonDetails().getVirtualEnv());
         files.exclude(standardExcludes());
         return files;
     }
@@ -102,7 +114,7 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask {
             public void execute(ExecSpec execSpec) {
                 execSpec.environment(getComponent().pythonEnvironment);
                 execSpec.environment(getComponent().pythonEnvironmentDistgradle);
-                execSpec.commandLine(VirtualEnvExecutableHelper.getPythonInterpreter(getComponent()));
+                execSpec.commandLine(VirtualEnvExecutableHelper.getPythonInterpreter(getPythonDetails()));
                 execSpec.args(arguments);
                 execSpec.args(additionalArguments);
                 execSpec.setStandardOutput(stdOut);

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
@@ -70,6 +71,7 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
         return new String[]{"**/*.pyc", "**/*.pyo", "**/__pycache__/"};
     }
 
+    @Internal
     public PythonExtension getComponent() {
         if (null == component) {
             component = getProject().getExtensions().getByType(PythonExtension.class);
@@ -77,6 +79,7 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
         return component;
     }
 
+    @Internal
     public PythonDetails getPythonDetails() {
         if (null == pythonDetails) {
             pythonDetails = getComponent().getDetails();
@@ -145,6 +148,7 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
 
     public abstract void processResults(ExecResult execResult);
 
+    @Internal
     @Override
     public String getReason() {
         return output;

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -48,12 +48,13 @@ import java.util.List;
 abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask implements FailureReasonProvider {
 
     FileTree sources;
+    private List<String> arguments = new ArrayList<>();
     private PythonExtension component;
     private PythonDetails pythonDetails;
     private String output;
-    
+
     @Input
-    public List<String> additionalArguments = new ArrayList<String>();
+    public List<String> additionalArguments = new ArrayList<>();
 
     @InputFiles
     public FileCollection getSourceFiles() {
@@ -118,15 +119,15 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
         ExecResult result = getProject().exec(new Action<ExecSpec>() {
             @Override
             public void execute(ExecSpec execSpec) {
-                container.execute(execSpec);
                 execSpec.environment(getComponent().pythonEnvironment);
                 execSpec.environment(getComponent().pythonEnvironmentDistgradle);
                 execSpec.commandLine(VirtualEnvExecutableHelper.getPythonInterpreter(getPythonDetails()));
                 execSpec.args(arguments);
                 execSpec.args(additionalArguments);
-                execSpec.setStandardOutput(stdOut);
-                execSpec.setErrorOutput(errOut);
                 execSpec.setIgnoreExitValue(ignoreExitValue);
+
+                container.execute(execSpec);
+
                 configureExecution(execSpec);
             }
         });

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildPexTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildPexTask.java
@@ -91,7 +91,7 @@ public class BuildPexTask extends DefaultTask implements FailureReasonProvider {
     }
 
     private void configureExecution(PythonExtension pythonExtension, ExecSpec spec) {
-        container.execute(spec);
+        container.setOutputs(spec);
         WheelExtension wheelExtension = ExtensionUtils.maybeCreateWheelExtension(getProject());
 
         spec.environment(pythonExtension.pythonEnvironment);

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildPexTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildPexTask.java
@@ -92,8 +92,8 @@ public class BuildPexTask extends DefaultTask {
 
         spec.environment(pythonExtension.pythonEnvironment);
         spec.environment(pythonExtension.pythonEnvironmentDistgradle);
-        spec.commandLine(VirtualEnvExecutableHelper.getPythonInterpreter(pythonExtension));
-        spec.args(VirtualEnvExecutableHelper.getPip(pythonExtension),
+        spec.commandLine(VirtualEnvExecutableHelper.getPythonInterpreter(pythonExtension.getDetails()));
+        spec.args(VirtualEnvExecutableHelper.getPip(pythonExtension.getDetails()),
             "wheel",
             "--disable-pip-version-check",
             "--wheel-dir",

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -23,6 +23,7 @@ import com.linkedin.gradle.python.util.ConsoleOutput
 import com.linkedin.gradle.python.util.ExtensionUtils
 import com.linkedin.gradle.python.util.PackageInfo
 import com.linkedin.gradle.python.util.VirtualEnvExecutableHelper
+import groovy.transform.TypeChecked
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -106,7 +107,7 @@ class BuildWheelsTask extends DefaultTask {
      * @param installables A collection of Python source distributions to compile as wheels.
      * @param env The environment to pass along to <pre>pip</pre>.
      */
-    protected static void buildWheels(Project project, Collection<File> installables, PythonDetails pythonDetails) {
+    protected void buildWheels(Project project, Collection<File> installables, PythonDetails pythonDetails) {
 
         WheelExtension wheelExtension = ExtensionUtils.getPythonComponentExtension(project, WheelExtension)
         def pythonExtension = ExtensionUtils.getPythonExtension(project)

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -23,7 +23,6 @@ import com.linkedin.gradle.python.util.ConsoleOutput
 import com.linkedin.gradle.python.util.ExtensionUtils
 import com.linkedin.gradle.python.util.PackageInfo
 import com.linkedin.gradle.python.util.VirtualEnvExecutableHelper
-import groovy.transform.TypeChecked
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -107,7 +106,7 @@ class BuildWheelsTask extends DefaultTask {
      * @param installables A collection of Python source distributions to compile as wheels.
      * @param env The environment to pass along to <pre>pip</pre>.
      */
-    protected void buildWheels(Project project, Collection<File> installables, PythonDetails pythonDetails) {
+    private void buildWheels(Project project, Collection<File> installables, PythonDetails pythonDetails) {
 
         WheelExtension wheelExtension = ExtensionUtils.getPythonComponentExtension(project, WheelExtension)
         def pythonExtension = ExtensionUtils.getPythonExtension(project)

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/Flake8Task.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/Flake8Task.groovy
@@ -23,7 +23,7 @@ import org.gradle.process.ExecResult
 public class Flake8Task extends AbstractPythonMainSourceDefaultTask {
 
   public void preExecution() {
-    args(VirtualEnvExecutableHelper.getExecutable(component, "bin/flake8").absolutePath,
+    args(VirtualEnvExecutableHelper.getExecutable(pythonDetails, "bin/flake8").absolutePath,
         "--config", "$component.setupCfg",
         "$component.srcDir",
         "$component.testDir")

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/InstallVirtualEnvironmentTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/InstallVirtualEnvironmentTask.groovy
@@ -74,7 +74,7 @@ class InstallVirtualEnvironmentTask extends DefaultTask implements FailureReason
         project.exec(new Action<ExecSpec>() {
             @Override
             void execute(ExecSpec execSpec) {
-                container.execute(execSpec)
+                container.setOutputs(execSpec)
                 execSpec.commandLine(
                     pythonDetails.getSystemPythonInterpreter(),
                     project.file("${packageDir}/virtualenv-${version}/virtualenv.py"),

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/InstallVirtualEnvironmentTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/InstallVirtualEnvironmentTask.groovy
@@ -15,7 +15,7 @@
  */
 package com.linkedin.gradle.python.tasks
 
-import com.linkedin.gradle.python.PythonExtension
+import com.linkedin.gradle.python.extension.PythonDetails
 import com.linkedin.gradle.python.tasks.execution.FailureReasonProvider
 import com.linkedin.gradle.python.tasks.execution.TeeOutputContainer
 import groovy.transform.CompileDynamic
@@ -37,14 +37,7 @@ import org.gradle.util.VersionNumber
 @CompileStatic
 class InstallVirtualEnvironmentTask extends DefaultTask implements FailureReasonProvider {
 
-    PythonExtension component
-
-    public PythonExtension getComponent() {
-        if (component == null) {
-            component = getProject().getExtensions().getByType(PythonExtension)
-        }
-        return component
-    }
+    private PythonDetails pythonDetails
 
     @InputFiles
     Configuration getPyGradleBootstrap() {
@@ -53,7 +46,7 @@ class InstallVirtualEnvironmentTask extends DefaultTask implements FailureReason
 
     @OutputFile
     File getVirtualEnvDir() {
-        return getComponent().getDetails().getVirtualEnvInterpreter()
+        return pythonDetails.getVirtualEnvInterpreter()
     }
 
     final TeeOutputContainer container = new TeeOutputContainer()
@@ -83,11 +76,11 @@ class InstallVirtualEnvironmentTask extends DefaultTask implements FailureReason
             void execute(ExecSpec execSpec) {
                 container.execute(execSpec)
                 execSpec.commandLine(
-                    getComponent().getDetails().getSystemPythonInterpreter(),
+                    pythonDetails.getSystemPythonInterpreter(),
                     project.file("${packageDir}/virtualenv-${version}/virtualenv.py"),
-                    '--python', getComponent().getDetails().getSystemPythonInterpreter(),
-                    '--prompt', getComponent().getDetails().virtualEnvPrompt,
-                    getComponent().getDetails().getVirtualEnv())
+                    '--python', pythonDetails.getSystemPythonInterpreter(),
+                    '--prompt', pythonDetails.virtualEnvPrompt,
+                    pythonDetails.getVirtualEnv())
             }
         })
         project.delete(packageDir)
@@ -114,6 +107,14 @@ class InstallVirtualEnvironmentTask extends DefaultTask implements FailureReason
     @Override
     String getReason() {
         return container.getCommandOutput()
+    }
+
+    public void setPythonDetails(PythonDetails pythonDetails) {
+        this.pythonDetails = pythonDetails
+    }
+
+    public PythonDetails getPythonDetails() {
+        return pythonDetails
     }
 
     private class VirtualEnvSpec implements Spec<Dependency> {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -98,14 +98,14 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
         def pyVersion = pythonDetails.getPythonVersion().pythonMajorMinor
         def extension = ExtensionUtils.getPythonExtension(project)
 
-        getConfigurationFiles().each { File installable ->
+        for (File installable : getConfigurationFiles()) {
 
             def packageInfo = PackageInfo.fromPath(installable.getAbsolutePath())
             def shortHand = packageInfo.version ? "${packageInfo.name}-${packageInfo.version}" : packageInfo.name
 
             if (packageExcludeFilter.isSatisfiedBy(packageInfo)) {
                 logger.lifecycle(PythonHelpers.createPrettyLine("Install ${shortHand}", "[EXCLUDED]"))
-                return
+                continue
             }
 
             String sanitizedName = packageInfo.name.replace('-', '_')
@@ -129,7 +129,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
 
             if (project.file(egg).exists() || project.file(dist).exists()) {
                 logger.lifecycle(PythonHelpers.createPrettyLine("Install ${shortHand}", "[SKIPPING]"))
-                return
+                continue
             }
 
             logger.lifecycle(PythonHelpers.createPrettyLine("Install ${shortHand}", "[STARTING]"))

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
@@ -46,6 +46,8 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
     void processResults(ExecResult execResult) {
         if (execResult.exitValue == NO_TESTS_COLLECTED_ERRNO) {
             logger.warn("***** WARNING: You did not write any tests! *****")
+        } else {
+            execResult.assertNormalExitValue()
         }
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
@@ -37,7 +37,7 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
 
     @Override
     public void preExecution() {
-        args(VirtualEnvExecutableHelper.findExecutable(component, "bin/py.test").absolutePath)
+        args(VirtualEnvExecutableHelper.findExecutable(pythonDetails, "bin/py.test").absolutePath)
         if (!specificFileGiven) {
             args(component.testDir)
         }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
@@ -20,7 +20,6 @@ import groovy.transform.CompileStatic
 import org.gradle.api.internal.tasks.options.Option
 import org.gradle.process.ExecResult
 
-
 /**
  * Run py.test on test directory
  */
@@ -47,8 +46,6 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
     void processResults(ExecResult execResult) {
         if (execResult.exitValue == NO_TESTS_COLLECTED_ERRNO) {
             logger.warn("***** WARNING: You did not write any tests! *****")
-        } else {
-            execResult.assertNormalExitValue()
         }
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
@@ -39,7 +39,7 @@ public class SourceDistTask extends DefaultTask {
             public void execute(ExecSpec execSpec) {
                 execSpec.environment(settings.pythonEnvironmentDistgradle);
                 execSpec.commandLine(
-                        VirtualEnvExecutableHelper.getPythonInterpreter(settings),
+                        VirtualEnvExecutableHelper.getPythonInterpreter(settings.getDetails()),
                         "setup.py",
                         "sdist",
                         "--dist-dir",

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
@@ -18,6 +18,8 @@ package com.linkedin.gradle.python.tasks;
 import java.io.File;
 
 import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.tasks.execution.FailureReasonProvider;
+import com.linkedin.gradle.python.tasks.execution.TeeOutputContainer;
 import com.linkedin.gradle.python.util.VirtualEnvExecutableHelper;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
@@ -27,8 +29,9 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecSpec;
 
 
-public class SourceDistTask extends DefaultTask {
+public class SourceDistTask extends DefaultTask implements FailureReasonProvider {
 
+    private TeeOutputContainer container = new TeeOutputContainer();
     @TaskAction
     public void packageSdist() {
 
@@ -37,6 +40,7 @@ public class SourceDistTask extends DefaultTask {
         getProject().exec(new Action<ExecSpec>() {
             @Override
             public void execute(ExecSpec execSpec) {
+                container.execute(execSpec);
                 execSpec.environment(settings.pythonEnvironmentDistgradle);
                 execSpec.commandLine(
                         VirtualEnvExecutableHelper.getPythonInterpreter(settings.getDetails()),
@@ -56,5 +60,10 @@ public class SourceDistTask extends DefaultTask {
 
     private File getDistDir() {
         return new File(getProject().getBuildDir(), "distributions");
+    }
+
+    @Override
+    public String getReason() {
+        return container.getCommandOutput();
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
@@ -40,7 +40,7 @@ public class SourceDistTask extends DefaultTask implements FailureReasonProvider
         getProject().exec(new Action<ExecSpec>() {
             @Override
             public void execute(ExecSpec execSpec) {
-                container.execute(execSpec);
+                container.setOutputs(execSpec);
                 execSpec.environment(settings.pythonEnvironmentDistgradle);
                 execSpec.commandLine(
                         VirtualEnvExecutableHelper.getPythonInterpreter(settings.getDetails()),

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SphinxDocumentationTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SphinxDocumentationTask.groovy
@@ -42,7 +42,7 @@ class SphinxDocumentationTask extends AbstractPythonMainSourceDefaultTask {
 
     @Override
     public void preExecution() {
-        args(VirtualEnvExecutableHelper.getExecutable(component, "bin/sphinx-build").absolutePath,
+        args(VirtualEnvExecutableHelper.getExecutable(pythonDetails, "bin/sphinx-build").absolutePath,
             '-b', type.builderName,
             project.file(component.docsDir).getAbsolutePath(),
             "${getDocDir().getAbsolutePath()}")

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/execution/FailureReasonProvider.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/execution/FailureReasonProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.tasks.execution;
+
+/**
+ * Used by tasks that will provide output messages when something goes wrong.
+ *
+ * This is useful for collecting metric information.
+ */
+public interface FailureReasonProvider {
+
+    /**
+     * @return the message for what went wrong
+     */
+    String getReason();
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/execution/TeeOutputContainer.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/execution/TeeOutputContainer.java
@@ -16,7 +16,6 @@
 package com.linkedin.gradle.python.tasks.execution;
 
 import org.apache.commons.io.output.TeeOutputStream;
-import org.gradle.api.Action;
 import org.gradle.process.ExecSpec;
 
 import java.io.ByteArrayOutputStream;
@@ -25,7 +24,7 @@ import java.io.OutputStream;
 /**
  * Collects all the output of commands so they can be used elsewhere
  */
-public class TeeOutputContainer implements Action<ExecSpec>  {
+public class TeeOutputContainer  {
 
     private final ByteArrayOutputStream mergedStream = new ByteArrayOutputStream();
     private final OutputStream teeStdOut;
@@ -41,8 +40,7 @@ public class TeeOutputContainer implements Action<ExecSpec>  {
     }
 
 
-    @Override
-    public void execute(ExecSpec execSpec) {
+    public void setOutputs(ExecSpec execSpec) {
         execSpec.setStandardOutput(teeStdOut);
         execSpec.setErrorOutput(teeErrOut);
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/execution/TeeOutputContainer.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/execution/TeeOutputContainer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.tasks.execution;
+
+import org.apache.commons.io.output.TeeOutputStream;
+import org.gradle.api.Action;
+import org.gradle.process.ExecSpec;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
+/**
+ * Collects all the output of commands so they can be used elsewhere
+ */
+public class TeeOutputContainer implements Action<ExecSpec>  {
+
+    private final ByteArrayOutputStream mergedStream = new ByteArrayOutputStream();
+    private final OutputStream teeStdOut;
+    private final OutputStream teeErrOut;
+
+    public TeeOutputContainer(OutputStream stdOut, OutputStream errOut) {
+        teeStdOut = new TeeOutputStream(stdOut, mergedStream);
+        teeErrOut = new TeeOutputStream(errOut, mergedStream);
+    }
+
+    public TeeOutputContainer() {
+        this(System.out, System.err);
+    }
+
+
+    @Override
+    public void execute(ExecSpec execSpec) {
+        execSpec.setStandardOutput(teeStdOut);
+        execSpec.setErrorOutput(teeErrOut);
+    }
+
+    public String getCommandOutput() {
+        return mergedStream.toString();
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
@@ -104,7 +104,12 @@ class PexFileUtil {
 
         /** Special cases, such as sphinx-rtd-theme with weird metadata */
         Set<String> specialCases = new HashSet<String>()
-        specialCases.addAll(['sphinx-rtd-theme', 'sphinx_rtd_theme'])
+        specialCases.addAll(['sphinx-rtd-theme',
+                             'sphinx_rtd_theme',
+                             'setuptools-scm',
+                             'setuptools_scm',
+                             'setuptools-subversion',
+                             'setuptools_subversion'])
 
         /** Setup requirements, build, and test dependencies + special cases */
         Set<String> developmentDependencies = configurationToSet(project.configurations.setupRequires.files)

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
@@ -65,9 +65,9 @@ class PexFileUtil {
             if (buildPexResult.exitValue != 0) {
                 def outputString = output.toString().trim()
                 println(outputString)
-                def packageMatcher = (outputString =~ /(?s).*Could not satisfy all requirements for ([\w\-]+):.*/)
+                def packageMatcher = (outputString =~ /(?s).*Could not satisfy all requirements for ([\w.-]+):.*/)
                 def packageName = "<see output above>"
-                if (packageMatcher.hasGroup()) {
+                if (packageMatcher.matches()) {
                     packageName = packageMatcher[0][1]
                 }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
@@ -78,6 +78,11 @@ class PexFileUtil {
                     | This typically happens because your virtual environment contains a cached copy of ${packageName}
                     | that no other package depends on any more.
                     | Usually, this is the result of updating a package that used to depend on ${packageName}.
+                    |
+                    | Another possible reason is that you started using a newer version of Python
+                    | without checking if all the libraries you use are compatible.
+                    | If you can find the missing package in the output above with the message
+                    | [EXCLUDED], then it works only with lower versions of Python.
                     """.stripMargin().stripIndent()
                 )
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/VirtualEnvExecutableHelper.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/VirtualEnvExecutableHelper.java
@@ -16,6 +16,7 @@
 package com.linkedin.gradle.python.util;
 
 import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.extension.PythonDetails;
 
 import java.io.File;
 
@@ -25,16 +26,31 @@ public class VirtualEnvExecutableHelper {
         //private constructor for util class
     }
 
+    @Deprecated
     public static File getPythonInterpreter(PythonExtension pythonExtension) {
-        return pythonExtension.getDetails().getVirtualEnvInterpreter();
+        return getPythonInterpreter(pythonExtension.getDetails());
     }
 
+    public static File getPythonInterpreter(PythonDetails pythonDetails) {
+        return pythonDetails.getVirtualEnvInterpreter();
+    }
+
+    @Deprecated
     public static File getPip(PythonExtension pythonExtension) {
-        return getExecutable(pythonExtension, "bin/pip");
+        return getPip(pythonExtension.getDetails());
     }
 
+    public static File getPip(PythonDetails pythonDetails) {
+        return getExecutable(pythonDetails, "bin/pip");
+    }
+
+    @Deprecated
     public static File getPex(PythonExtension pythonExtension) {
-        return getExecutable(pythonExtension, "bin/pex");
+        return getPex(pythonExtension.getDetails());
+    }
+
+    public static File getPex(PythonDetails pythonDetails) {
+        return getExecutable(pythonDetails, "bin/pex");
     }
 
     public static File getExecutable(File file) {
@@ -45,11 +61,21 @@ public class VirtualEnvExecutableHelper {
         return file;
     }
 
+    @Deprecated
     public static File getExecutable(PythonExtension pythonExtension, String path) {
-        return getExecutable(new File(pythonExtension.getDetails().getVirtualEnv(), path));
+        return getExecutable(pythonExtension.getDetails(), path);
     }
 
+    public static File getExecutable(PythonDetails pythonDetails, String path) {
+        return getExecutable(new File(pythonDetails.getVirtualEnv(), path));
+    }
+
+    @Deprecated
     public static File findExecutable(PythonExtension pythonExtension, String path) {
-        return new File(pythonExtension.getDetails().getVirtualEnv(), path);
+        return findExecutable(pythonExtension.getDetails(), path);
+    }
+
+    public static File findExecutable(PythonDetails pythonDetails, String path) {
+        return new File(pythonDetails.getVirtualEnv(), path);
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecSpecAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecSpecAction.java
@@ -67,8 +67,8 @@ class PexExecSpecAction implements Action<ExecSpec> {
 
     @Override
     public void execute(ExecSpec execSpec) {
-        execSpec.commandLine(VirtualEnvExecutableHelper.getPythonInterpreter(pythonExtension));
-        execSpec.args(VirtualEnvExecutableHelper.getPex(pythonExtension));
+        execSpec.commandLine(VirtualEnvExecutableHelper.getPythonInterpreter(pythonExtension.getDetails()));
+        execSpec.args(VirtualEnvExecutableHelper.getPex(pythonExtension.getDetails()));
 
         System.out.println(outputFile.getAbsolutePath());
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
@@ -64,8 +64,8 @@ class PipFreezeAction {
             public void execute(ExecSpec execSpec) {
                 execSpec.environment(settings.getEnvironment());
                 execSpec.commandLine(
-                    VirtualEnvExecutableHelper.getPythonInterpreter(settings),
-                    VirtualEnvExecutableHelper.getPip(settings),
+                    VirtualEnvExecutableHelper.getPythonInterpreter(settings.getDetails()),
+                    VirtualEnvExecutableHelper.getPip(settings.getDetails()),
                     "freeze",
                     "--disable-pip-version-check"
                 );


### PR DESCRIPTION
This change makes it where things operate off the PythonDetails object
vs the PythonExtension object. This will allow the creation of multiple
different venvs where they contain different versions of python.

This also makes it where the PipInstallTasks have a way to filter
dependencies, this will allow us to use extra-requires filters to
add/remove dependencies.