### PR TITLE
Fix the handling of special cases.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
@@ -26,7 +26,6 @@ import org.gradle.process.ExecSpec;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -44,16 +43,15 @@ class PipFreezeAction {
     public List<String> getDependencies() {
         final PythonExtension settings = ExtensionUtils.getPythonExtension(project);
 
-        // Setup requirements, build, and test dependencies + special cases
+        // Setup requirements, build, and test dependencies
         Set<String> developmentDependencies = configurationToSet(project, PythonPlugin.CONFIGURATION_SETUP_REQS);
         developmentDependencies.addAll(configurationToSet(project, PythonPlugin.CONFIGURATION_BUILD_REQS));
         developmentDependencies.addAll(configurationToSet(project, PythonPlugin.CONFIGURATION_TEST));
 
-        // Special cases, such as sphinx-rtd-theme with weird metadata
-        developmentDependencies.addAll(Arrays.asList("sphinx-rtd-theme", "sphinx_rtd_theme"));
         developmentDependencies.removeAll(configurationToSet(project, PythonPlugin.CONFIGURATION_PYTHON));
 
-        if (Objects.equals(settings.getDetails().getPythonVersion().getPythonMajorMinor(), "2.6") && developmentDependencies.contains("argparse")) {
+        if (Objects.equals(settings.getDetails().getPythonVersion().getPythonMajorMinor(), "2.6")
+            && developmentDependencies.contains("argparse")) {
             developmentDependencies.remove("argparse");
         }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParser.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParser.java
@@ -36,7 +36,9 @@ class PipFreezeOutputParser {
         for (String it : requirements.split("\n")) {
             String[] split = it.split("==");
             String name = split[0];
-            if (!ignoredDependencies.contains(name)) {
+            // The tar name can have _ when package name has -, so check both.
+            if (!(ignoredDependencies.contains(name)
+                || ignoredDependencies.contains(name.replace("-", "_")))) {
                 reqs.add(name);
             }
         }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParserTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParserTest.groovy
@@ -49,10 +49,11 @@ class PipFreezeOutputParserTest extends Specification {
             |wheel==0.26.0'''.stripMargin().stripIndent()
 
         expect:
-        PipFreezeOutputParser.getDependencies(
-            ['pbr', 'Babel', 'pep8', 'py', 'setuptools', 'pytest-xdist', 'Jinja2', 'flake8', 'snowballstemmer',
-             'alabaster', 'sphinx_rtd_theme', 'Pygments', 'pytest-cov', 'pip', 'mccabe', 'docutils', 'coverage', 'pex',
-             'six', 'setuptools-git', 'pyflakes', 'pytest', 'sphinx-rtd-theme', 'wheel', 'imagesize', 'argparse',
-             'Sphinx', 'colorama', 'pytz'], freezeOutput) == ['testProject']
+        PipFreezeOutputParser.getDependencies([
+            'pbr', 'Babel', 'pep8', 'py', 'setuptools', 'pytest-xdist', 'Jinja2', 'flake8', 'snowballstemmer',
+            'alabaster', 'sphinx_rtd_theme', 'Pygments', 'pytest-cov', 'pip', 'mccabe', 'docutils', 'coverage', 'pex',
+            'six', 'setuptools-git', 'pyflakes', 'pytest', 'wheel', 'imagesize', 'argparse', 'Sphinx', 'colorama',
+            'pytz'
+        ], freezeOutput) == ['testProject']
     }
 }


### PR DESCRIPTION
The Python packages with underscores in their name have the tar files
with the underscore ("_") in the file name, but the dash ("-") in the
package name in the metadata. Similarly in Ivy files for Gradle.
Instead of saving each special case in the map, we're going to handle it
generically for each such possible package name.