### PR TITLE
Fix incorrect dependency to pypi:requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For a quick start, lets look at a simple example of publishing a library using t
     }
 
     dependencies {
-        python 'pypi:requests:2.5.1'
+        python 'pypi:requests:2.9.1'
         test 'pypi:mock:1.0.1'
     }
     


### PR DESCRIPTION
Fixed dependency from pypi:requests 2.5.1 to 2.9.1