### PR TITLE
Enable junit test reporting by default

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PyGradleTestBuilder.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PyGradleTestBuilder.groovy
@@ -24,7 +24,7 @@ class PyGradleTestBuilder {
             | max-line-length = 160
             |
             | [pytest]
-            | addopts = --ignore build/ --ignore dist/
+            | addopts = --ignore build/ --ignore dist/ --junitxml TEST-pytest.xml
             '''.stripMargin().stripIndent()
     }
 


### PR DESCRIPTION
Providing a jUnit xml report by default is useful for continuous integration systems.
