### PR TITLE
Output time stamp logging down to the millisecond.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -164,7 +164,7 @@ class BuildWheelsTask extends DefaultTask {
                 if (pythonExtension.consoleOutput == ConsoleOutput.RAW) {
                     LOGGER.lifecycle(stream.toString().trim())
                 } else {
-                    String prefix = String.format(messageHead + ' (%d:%02d s)', duration.toMinutes(), duration.getSeconds() % 60)
+                    String prefix = String.format(messageHead + ' (%d:%02d.%03d s)', duration.toMinutes(), duration.getSeconds() % 60, (int)(duration.getNano() / 1000000))
                     LOGGER.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -164,7 +164,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
                 if (extension.consoleOutput == ConsoleOutput.RAW) {
                     logger.lifecycle(message)
                 } else {
-                    String prefix = String.format("Install %s (%d:%02d s)", shortHand, duration.toMinutes(), duration.getSeconds() % 60)
+                    String prefix = String.format("Install (%d:%02d.%03d s)", duration.toMinutes(), duration.getSeconds() % 60, (int)(duration.getNano() / 1000000))
                     logger.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }


### PR DESCRIPTION
Gives finer time resolution for pip installs and wheel builds. New output looks like:

    Install setuptools-19.1.1 ........................................... [STARTING]
    Install (0:01.354 s) ................................................ [FINISHED]
    Install simplejson-3.8.1 ............................................ [STARTING]
    Install (0:02.291 s) ................................................ [FINISHED]

and

    Preparing wheel setuptools-19.1.1 ................................... [STARTING]
    Preparing wheel setuptools-19.1.1 (0:01.470 s) ...................... [FINISHED]
    Preparing wheel simplejson-3.8.1 .................................... [STARTING]
    Preparing wheel simplejson-3.8.1 (0:02.217 s) ....................... [FINISHED]