### PR TITLE
Add gradle version guidance to example project.

### DIFF
--- a/examples/example-project/README.md
+++ b/examples/example-project/README.md
@@ -18,7 +18,7 @@ $ tree
 
 *Note the lack of a setup.py, more on this in a moment...*
 
-If you have not already installed Gradle, feel free to do so now, [documentation here](https://docs.gradle.org/current/userguide/installation.html). Or, if you are using osx and brew you can simple `brew install gradle`.
+If you have not already installed Gradle (preferably version 3.0+, but we strive to be backwards compatible with 2.10+), feel free to do so now, [documentation here](https://docs.gradle.org/current/userguide/installation.html). Or, if you are using osx and brew you can simply `brew install gradle`.
 
 Add a top level `build.gradle` file that leverages {py}gradle:
 

--- a/examples/example-project/build.gradle
+++ b/examples/example-project/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.linkedin.python-sdist" version "0.3.9"
+  id "com.linkedin.python-sdist" version "0.3.29"
 }
 
 dependencies {


### PR DESCRIPTION
use newest pygradle in example-project's build.gradle