### PR TITLE
packageSdist should on incremental builds if source changes. Fixes #80

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -37,7 +37,7 @@ task importRequiredDependencies(type: JavaExec) { task ->
 
     def replacements = ['alabaster:0.7=alabaster:0.7.1', 'pytz:0a=pytz:2016.4', 'Babel:0.8=Babel:1.0',
                         'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1', 'chardet:2.2=chardet:2.3.0',
-                        'setuptools:0.6a2=setuptools:19.1.1'].join(",")
+                        'setuptools:0.6a2=setuptools:19.1.1', 'idna:2.0.0=idna:2.0'].join(",")
     def packagesToInclude = ['virtualenv:15.0.1', 'pip:7.1.2', 'setuptools:19.1.1', 'setuptools-git:1.1',
                              'flake8:2.4.0', 'flake8:2.5.4', 'pytest:2.9.1', 'pytest-cov:2.2.1', 'pytest-xdist:1.14',
                              'wheel:0.26.0', 'pbr:1.8.0', 'Sphinx:1.4.1', 'six:1.10.0', 'pex:1.1.4',

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -68,7 +68,7 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
     }
 
     public String[] standardExcludes() {
-        return new String[]{"**/*.pyc", "**/*.pyo", "**/__pycache__/"};
+        return new String[]{"**/*.pyc", "**/*.pyo", "**/__pycache__/", "**/*.egg-info/"};
     }
 
     @Internal

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
@@ -17,39 +17,19 @@ package com.linkedin.gradle.python.tasks;
 
 import java.io.File;
 
-import com.linkedin.gradle.python.PythonExtension;
-import com.linkedin.gradle.python.tasks.execution.FailureReasonProvider;
-import com.linkedin.gradle.python.tasks.execution.TeeOutputContainer;
-import com.linkedin.gradle.python.util.VirtualEnvExecutableHelper;
-import org.gradle.api.Action;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.TaskAction;
-import org.gradle.process.ExecSpec;
+import org.gradle.process.ExecResult;
 
 
-public class SourceDistTask extends DefaultTask implements FailureReasonProvider {
+public class SourceDistTask extends AbstractPythonMainSourceDefaultTask {
 
-    private TeeOutputContainer container = new TeeOutputContainer();
-    @TaskAction
-    public void packageSdist() {
+    public SourceDistTask() {
+        args("setup.py", "sdist", "--dist-dir", getDistDir().getAbsolutePath());
+    }
 
-        final PythonExtension settings = getProject().getExtensions().getByType(PythonExtension.class);
-
-        getProject().exec(new Action<ExecSpec>() {
-            @Override
-            public void execute(ExecSpec execSpec) {
-                container.setOutputs(execSpec);
-                execSpec.environment(settings.pythonEnvironmentDistgradle);
-                execSpec.commandLine(
-                        VirtualEnvExecutableHelper.getPythonInterpreter(settings.getDetails()),
-                        "setup.py",
-                        "sdist",
-                        "--dist-dir",
-                        getDistDir().getAbsolutePath());
-            }
-        });
+    @Override
+    public void processResults(ExecResult execResult) {
     }
 
     @OutputFile
@@ -62,8 +42,4 @@ public class SourceDistTask extends DefaultTask implements FailureReasonProvider
         return new File(getProject().getBuildDir(), "distributions");
     }
 
-    @Override
-    public String getReason() {
-        return container.getCommandOutput();
-    }
 }


### PR DESCRIPTION
- extend from AbstractPythonMainSourceDefaultTask instead of DefaultTask
  for correct Inputs.
- Exclude *.egg-info directories from Inputfiles.