### PR TITLE
Fix SourceDistTask with underscore in version

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
@@ -35,7 +35,8 @@ public class SourceDistTask extends AbstractPythonMainSourceDefaultTask {
     @OutputFile
     public File getSdistOutput() {
         Project project = getProject();
-        return new File(getDistDir(), 
+        return new File(
+                getDistDir(), 
                 String.format(
                         "%s-%s.tar.gz", 
                         project.getName(), 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/SourceDistTask.java
@@ -35,7 +35,11 @@ public class SourceDistTask extends AbstractPythonMainSourceDefaultTask {
     @OutputFile
     public File getSdistOutput() {
         Project project = getProject();
-        return new File(getDistDir(), String.format("%s-%s.tar.gz", project.getName(), project.getVersion()));
+        return new File(getDistDir(), 
+                String.format(
+                        "%s-%s.tar.gz", 
+                        project.getName(), 
+                        project.getVersion().toString().replace("_", "-")));
     }
 
     private File getDistDir() {


### PR DESCRIPTION
The project's version number, if it contains a `_` needs to be converted to a `-`.

Closes #84