### PR TITLE
Replace Java8 syntax with Java7

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -23,13 +23,10 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
-
-import java.util.function.Consumer
 
 @SuppressWarnings("AbcMetric")
 //TODO: Break apart method
@@ -130,12 +127,9 @@ class PythonPlugin implements Plugin<Project> {
          * good versions that satisfy all the requirements.
          */
         def dependencyResolveDetails = new PyGradleDependencyResolveDetails(settings.forcedVersions)
-        project.configurations.forEach(new Consumer<Configuration>() {
-            @Override
-            void accept(Configuration configuration) {
-                configuration.resolutionStrategy.eachDependency(dependencyResolveDetails)
-            }
-        })
+        project.configurations.each { configuration ->
+            configuration.resolutionStrategy.eachDependency(dependencyResolveDetails)
+        }
 
         /*
          * Write the direct dependencies into a requirements file as a list of pinned versions.

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -23,6 +23,7 @@ import com.linkedin.gradle.python.util.ConsoleOutput
 import com.linkedin.gradle.python.util.ExtensionUtils
 import com.linkedin.gradle.python.util.PackageInfo
 import com.linkedin.gradle.python.util.VirtualEnvExecutableHelper
+import groovy.time.TimeCategory
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -33,8 +34,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
-
-import java.util.concurrent.TimeUnit
 
 class BuildWheelsTask extends DefaultTask {
 
@@ -137,7 +136,7 @@ class BuildWheelsTask extends DefaultTask {
 
             LOGGER.lifecycle(PythonHelpers.createPrettyLine(messageHead, "[STARTING]"))
 
-            def startTime = System.currentTimeMillis()
+            def startTime = new Date()
             ExecResult installResult = project.exec { ExecSpec execSpec ->
                 execSpec.environment pythonExtension.pythonEnvironment
                 execSpec.commandLine(
@@ -153,8 +152,8 @@ class BuildWheelsTask extends DefaultTask {
                 execSpec.errorOutput = stream
                 execSpec.ignoreExitValue = true
             }
-            def endTime = System.currentTimeMillis()
-            def duration = endTime - startTime
+            def endTime = new Date()
+            def duration = TimeCategory.minus(endTime, startTime)
 
             if (installResult.exitValue != 0) {
                 LOGGER.error(stream.toString().trim())
@@ -163,7 +162,7 @@ class BuildWheelsTask extends DefaultTask {
                 if (pythonExtension.consoleOutput == ConsoleOutput.RAW) {
                     LOGGER.lifecycle(stream.toString().trim())
                 } else {
-                    String prefix = String.format("Install (%d s)", TimeUnit.MILLISECONDS.toSeconds(duration))
+                    String prefix = String.format(messageHead + " (%d:%02d s)", duration.minutes, duration.seconds % 60)
                     LOGGER.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -34,8 +34,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 
-import java.time.Duration
-import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
 class BuildWheelsTask extends DefaultTask {
 
@@ -138,7 +137,7 @@ class BuildWheelsTask extends DefaultTask {
 
             LOGGER.lifecycle(PythonHelpers.createPrettyLine(messageHead, "[STARTING]"))
 
-            def startTime = LocalDateTime.now()
+            def startTime = System.currentTimeMillis()
             ExecResult installResult = project.exec { ExecSpec execSpec ->
                 execSpec.environment pythonExtension.pythonEnvironment
                 execSpec.commandLine(
@@ -154,8 +153,8 @@ class BuildWheelsTask extends DefaultTask {
                 execSpec.errorOutput = stream
                 execSpec.ignoreExitValue = true
             }
-            def endTime = LocalDateTime.now()
-            def duration = Duration.between(startTime, endTime)
+            def endTime = System.currentTimeMillis()
+            def duration = endTime - startTime
 
             if (installResult.exitValue != 0) {
                 LOGGER.error(stream.toString().trim())
@@ -164,7 +163,7 @@ class BuildWheelsTask extends DefaultTask {
                 if (pythonExtension.consoleOutput == ConsoleOutput.RAW) {
                     LOGGER.lifecycle(stream.toString().trim())
                 } else {
-                    String prefix = String.format(messageHead + ' (%d:%02d.%03d s)', duration.toMinutes(), duration.getSeconds() % 60, (int)(duration.getNano() / 1000000))
+                    String prefix = String.format("Install (%d s)", TimeUnit.MILLISECONDS.toSeconds(duration))
                     LOGGER.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -162,7 +162,7 @@ class BuildWheelsTask extends DefaultTask {
                 if (pythonExtension.consoleOutput == ConsoleOutput.RAW) {
                     LOGGER.lifecycle(stream.toString().trim())
                 } else {
-                    String prefix = String.format(messageHead + " (%d:%02d s)", duration.minutes, duration.seconds % 60)
+                    String prefix = String.format(messageHead + " (%d:%02d.%03d s)", duration.minutes, duration.seconds % 60, duration.millis % 1000)
                     LOGGER.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -34,8 +34,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 
-import java.time.Duration
-import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 
 /**
  * Execute pip install
@@ -134,7 +133,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
 
             logger.lifecycle(PythonHelpers.createPrettyLine("Install ${shortHand}", "[STARTING]"))
 
-            def startTime = LocalDateTime.now()
+            def startTime = System.currentTimeMillis()
             def stream = new ByteArrayOutputStream()
             ExecResult installResult = project.exec { ExecSpec execSpec ->
                 execSpec.environment mergedEnv
@@ -143,8 +142,8 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
                 execSpec.errorOutput = stream
                 execSpec.ignoreExitValue = true
             }
-            def endTime = LocalDateTime.now()
-            def duration = Duration.between(startTime, endTime)
+            def endTime = System.currentTimeMillis()
+            def duration = endTime - startTime
 
             def message = stream.toString().trim()
             if (installResult.exitValue != 0) {
@@ -164,7 +163,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
                 if (extension.consoleOutput == ConsoleOutput.RAW) {
                     logger.lifecycle(message)
                 } else {
-                    String prefix = String.format("Install (%d:%02d.%03d s)", duration.toMinutes(), duration.getSeconds() % 60, (int)(duration.getNano() / 1000000))
+                    String prefix = String.format("Install (%d s)", TimeUnit.MILLISECONDS.toSeconds(duration))
                     logger.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -22,6 +22,7 @@ import com.linkedin.gradle.python.util.ConsoleOutput
 import com.linkedin.gradle.python.util.ExtensionUtils
 import com.linkedin.gradle.python.util.PackageInfo
 import com.linkedin.gradle.python.util.VirtualEnvExecutableHelper
+import groovy.time.TimeCategory
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -33,8 +34,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
-
-import java.util.concurrent.TimeUnit
 
 /**
  * Execute pip install
@@ -133,7 +132,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
 
             logger.lifecycle(PythonHelpers.createPrettyLine("Install ${shortHand}", "[STARTING]"))
 
-            def startTime = System.currentTimeMillis()
+            def startTime = new Date()
             def stream = new ByteArrayOutputStream()
             ExecResult installResult = project.exec { ExecSpec execSpec ->
                 execSpec.environment mergedEnv
@@ -142,8 +141,8 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
                 execSpec.errorOutput = stream
                 execSpec.ignoreExitValue = true
             }
-            def endTime = System.currentTimeMillis()
-            def duration = endTime - startTime
+            def endTime = new Date()
+            def duration = TimeCategory.minus(endTime, startTime)
 
             def message = stream.toString().trim()
             if (installResult.exitValue != 0) {
@@ -163,7 +162,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
                 if (extension.consoleOutput == ConsoleOutput.RAW) {
                     logger.lifecycle(message)
                 } else {
-                    String prefix = String.format("Install (%d s)", TimeUnit.MILLISECONDS.toSeconds(duration))
+                    String prefix = String.format("Install (%d:%02d s)", duration.minutes, duration.seconds % 60)
                     logger.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -162,7 +162,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider {
                 if (extension.consoleOutput == ConsoleOutput.RAW) {
                     logger.lifecycle(message)
                 } else {
-                    String prefix = String.format("Install (%d:%02d s)", duration.minutes, duration.seconds % 60)
+                    String prefix = String.format("Install (%d:%02d.%03d s)", duration.minutes, duration.seconds % 60, duration.millis % 1000)
                     logger.lifecycle(PythonHelpers.createPrettyLine(prefix, "[FINISHED]"))
                 }
             }


### PR DESCRIPTION
Since Gradle 3.x requires support for Java7 I've updated the plugin to use only Java7 syntax

Related to Issue #26 