### PR TITLE
Will lazy evaluate vs eager

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -41,8 +41,9 @@ task importRequiredDependencies(type: JavaExec) { task ->
     def packagesToInclude = ['virtualenv:15.0.1', 'pip:7.1.2', 'setuptools:19.1.1', 'setuptools-git:1.1',
                              'flake8:2.4.0', 'flake8:2.5.4', 'pytest:2.9.1', 'pytest-cov:2.2.1', 'pytest-xdist:1.14',
                              'wheel:0.26.0', 'pbr:1.8.0', 'Sphinx:1.4.1', 'six:1.10.0', 'pex:1.1.4',
-                             'requests:2.10.0', 'Flask:0.11.1'].join(" ")
-    args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements".split(' ')
+                             'requests:2.10.0', 'Flask:0.11.1', 'docutils:0.12'].join(" ")
+    def forceDeps = ['docutils:0.12'].join(',')
+    args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements --force $forceDeps".split(' ')
 
     outputs.dir(getIvyRepo())
     inputs.property('packages', packagesToInclude)

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencyDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencyDownloader.groovy
@@ -59,6 +59,10 @@ class DependencyDownloader {
         version = projectDetails.maybeFixVersion(version)
         def sdistDetails = projectDetails.findVersion(version).find { it.packageType == 'sdist' }
 
+        if (sdistDetails == null) {
+            throw new RuntimeException("Unable to find source dist for $dep")
+        }
+
         def destDir = new File(ivyRepoRoot, "pypi/${name}/${version}")
 
         destDir.mkdirs()

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencySubstitution.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencySubstitution.groovy
@@ -18,12 +18,18 @@ package com.linkedin.python.importer.deps
 class DependencySubstitution {
 
     final Map<String, String> replacementMap
+    final Map<String, String> forceMap
 
-    DependencySubstitution(Map<String, String> replacementMap) {
+    DependencySubstitution(Map<String, String> replacementMap, Map<String, String> forceMap) {
         this.replacementMap = replacementMap
+        this.forceMap = forceMap
     }
 
     String maybeReplace(String dependency) {
+        def name = dependency.split(":")[0]
+        if (forceMap.containsKey(name)) {
+            return "$name:${forceMap[name]}"
+        }
         if (replacementMap.containsKey(dependency)) {
             return replacementMap.get(dependency)
         } else {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
@@ -123,10 +123,6 @@ public class PythonDetails implements Serializable {
 
     public void setSystemPythonInterpreter(String path) {
         pythonInterpreter = new File(path);
-        if (!pythonInterpreter.exists()) {
-            throw new RuntimeException("Unable to find " + path);
-        }
-
         updateFromPythonInterpreter();
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
@@ -42,9 +42,6 @@ public class PythonDetails implements Serializable {
 
     public PythonDetails(Project project, File venvDir) {
         this.project = project;
-        pythonInterpreter = new File("/usr/bin/python");
-        updateFromPythonInterpreter();
-
         activateLink = new File(project.getProjectDir(), "activate");
         virtualEnvPrompt = String.format("(%s)", project.getName());
         searchPath = ExecutablePathUtils.getPath();
@@ -79,6 +76,7 @@ public class PythonDetails implements Serializable {
     }
 
     public File getSystemPythonInterpreter() {
+        findPythonWhenAbsent();
         return pythonInterpreter;
     }
 
@@ -133,6 +131,17 @@ public class PythonDetails implements Serializable {
     }
 
     public PythonVersion getPythonVersion() {
+        findPythonWhenAbsent();
         return pythonVersion;
+    }
+
+    private void findPythonWhenAbsent() {
+        if (pythonInterpreter == null) {
+            File python = ExecutablePathUtils.getExecutable(searchPath, "python");
+            if (python == null) {
+                python = new File("/usr/bin/python");
+            }
+            setSystemPythonInterpreter(python.getAbsolutePath());
+        }
     }
 }


### PR DESCRIPTION
This was done because some use-cases (Windows) don't have
/usr/bin/python and thus would never be able to build. So this way the
user can get in early and specify their own python interpreter or update
the path so the plugin can find python. It will still default to
/usr/bin/python if nothing matches