### PR TITLE
Declare setuptools dependencies as setup requirements.

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -41,7 +41,8 @@ task importRequiredDependencies(type: JavaExec) { task ->
     def packagesToInclude = ['virtualenv:15.0.1', 'pip:7.1.2', 'setuptools:19.1.1', 'setuptools-git:1.1',
                              'flake8:2.4.0', 'flake8:2.5.4', 'pytest:2.9.1', 'pytest-cov:2.2.1', 'pytest-xdist:1.14',
                              'wheel:0.26.0', 'pbr:1.8.0', 'Sphinx:1.4.1', 'six:1.10.0', 'pex:1.1.4',
-                             'requests:2.10.0', 'Flask:0.11.1', 'docutils:0.12'].join(" ")
+                             'requests:2.10.0', 'Flask:0.11.1', 'docutils:0.12', 'appdirs:1.4.0',
+                             'packaging:16.8'].join(" ")
     def forceDeps = ['docutils:0.12'].join(',')
     args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements --force $forceDeps".split(' ')
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -58,8 +58,10 @@ class PythonExtension {
 
     /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
+        'appdirs'       : ['group': 'pypi', 'name': 'appdirs', 'version': '1.4.0'],
         'argparse'      : ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '2.5.4'],
+        'packaging'     : ['group': 'pypi', 'name': 'packaging', 'version': '16.8'],
         'pbr'           : ['group': 'pypi', 'name': 'pbr', 'version': '1.8.0'],
         'pex'           : ['group': 'pypi', 'name': 'pex', 'version': '1.1.4'],
         'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '7.1.2'],

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -108,8 +108,10 @@ class PythonPlugin implements Plugin<Project> {
          */
         project.dependencies.add(CONFIGURATION_BOOTSTRAP_REQS, settings.forcedVersions['virtualenv'])
 
-        project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['setuptools'])
+        project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['appdirs'])
+        project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['packaging'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['wheel'])
+        project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['setuptools'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['pip'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['setuptools-git'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS, settings.forcedVersions['pbr'])


### PR DESCRIPTION
Setuptools changed recently and stopped vending its dependencies.
Instead, it declares them like any other Python package.
Thus, we need to add these into setupRequires so that they can be
appropriately excluded from PEX when it's built (unless some package
declares them as runtime dependencies).