### PR TITLE
Update appdirs.

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -38,11 +38,27 @@ task importRequiredDependencies(type: JavaExec) { task ->
     def replacements = ['alabaster:0.7=alabaster:0.7.1', 'pytz:0a=pytz:2016.4', 'Babel:0.8=Babel:1.0',
                         'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1', 'chardet:2.2=chardet:2.3.0',
                         'setuptools:0.6a2=setuptools:19.1.1', 'idna:2.0.0=idna:2.0'].join(",")
-    def packagesToInclude = ['virtualenv:15.0.1', 'pip:7.1.2', 'setuptools:19.1.1', 'setuptools-git:1.1',
-                             'flake8:2.4.0', 'flake8:2.5.4', 'pytest:2.9.1', 'pytest-cov:2.2.1', 'pytest-xdist:1.14',
-                             'wheel:0.26.0', 'pbr:1.8.0', 'Sphinx:1.4.1', 'six:1.10.0', 'pex:1.1.4',
-                             'requests:2.10.0', 'Flask:0.11.1', 'docutils:0.12', 'appdirs:1.4.0',
-                             'packaging:16.8'].join(" ")
+    def packagesToInclude = [
+        'appdirs:1.4.1',
+        'docutils:0.12',
+        'flake8:2.4.0',
+        'flake8:2.5.4',
+        'Flask:0.11.1',
+        'packaging:16.8',
+        'pbr:1.8.0',
+        'pex:1.1.4',
+        'pip:7.1.2',
+        'pytest-cov:2.2.1',
+        'pytest-xdist:1.14',
+        'pytest:2.9.1',
+        'requests:2.10.0',
+        'setuptools-git:1.1',
+        'setuptools:19.1.1',
+        'six:1.10.0',
+        'Sphinx:1.4.1',
+        'virtualenv:15.0.1',
+        'wheel:0.26.0',
+    ].join(" ")
     def forceDeps = ['docutils:0.12'].join(',')
     args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements --force $forceDeps".split(' ')
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -65,7 +65,7 @@ class PythonExtension {
 
     /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
-        'appdirs'       : ['group': 'pypi', 'name': 'appdirs',          'version': '1.4.0'],
+        'appdirs'       : ['group': 'pypi', 'name': 'appdirs',          'version': '1.4.1'],
         'argparse'      : ['group': 'pypi', 'name': 'argparse',         'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8',           'version': '2.5.4'],
         'packaging'     : ['group': 'pypi', 'name': 'packaging',        'version': '16.8'],


### PR DESCRIPTION
Setuptools picks this from PyPI as the newest version.
We need to update to reduce possible issues with downgrading until we
fix the behavior of setuptools search for setup requirements from
pygradle.