### PR TITLE
Control setuptools behavior in PyGradle.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -65,10 +65,8 @@ class PythonExtension {
 
     /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
-        'appdirs'       : ['group': 'pypi', 'name': 'appdirs',          'version': '1.4.3'],
         'argparse'      : ['group': 'pypi', 'name': 'argparse',         'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8',           'version': '2.5.4'],
-        'packaging'     : ['group': 'pypi', 'name': 'packaging',        'version': '16.8'],
         'pbr'           : ['group': 'pypi', 'name': 'pbr',              'version': '1.8.0'],
         'pex'           : ['group': 'pypi', 'name': 'pex',              'version': '1.1.4'],
         'pip'           : ['group': 'pypi', 'name': 'pip',              'version': '7.1.2'],

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -79,8 +79,6 @@ class PythonPlugin implements Plugin<Project> {
          */
         project.dependencies.add(CONFIGURATION_BOOTSTRAP_REQS.value, settings.forcedVersions['virtualenv'])
 
-        project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['appdirs'])
-        project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['packaging'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['wheel'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['setuptools'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['pip'])


### PR DESCRIPTION
This change fixes two issues:

- Setuptools resolves `setup_requires` (not pip) by looking at PyPI.
  It can be configured to look only on an organization's *intranet*
  instead. This is optional because not everyone needs it, but those who
  do can now supply the custom sections of distutils.cfg and tightly
  control the behavior.
- Virtualenv was downloading the *latest* versions of setuptools, wheel,
  and pip of PyPI. That started causing problems when setuptools changed
  recently (version >= 34.x) and declared its own dependencies.
  This change is using the versions vended with virtualenv and prevents
  the download.