### PR TITLE
Change installation order to post-order graph traversal.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -67,7 +67,6 @@ class PythonExtension {
     public Map<String, Map<String, String>> forcedVersions = [
         'argparse'      : ['group': 'pypi', 'name': 'argparse',         'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8',           'version': '2.5.4'],
-        'pbr'           : ['group': 'pypi', 'name': 'pbr',              'version': '1.8.0'],
         'pex'           : ['group': 'pypi', 'name': 'pex',              'version': '1.1.4'],
         'pip'           : ['group': 'pypi', 'name': 'pip',              'version': '7.1.2'],
         'pytest'        : ['group': 'pypi', 'name': 'pytest',           'version': '2.9.1'],
@@ -75,7 +74,6 @@ class PythonExtension {
         'pytest-xdist'  : ['group': 'pypi', 'name': 'pytest-xdist',     'version': '1.14'],
         'setuptools'    : ['group': 'pypi', 'name': 'setuptools',       'version': '19.1.1'],
         'setuptools-git': ['group': 'pypi', 'name': 'setuptools-git',   'version': '1.1'],
-        'six'           : ['group': 'pypi', 'name': 'six',              'version': '1.10.0'],
         'Sphinx'        : ['group': 'pypi', 'name': 'Sphinx',           'version': '1.4.1'],
         'virtualenv'    : ['group': 'pypi', 'name': 'virtualenv',       'version': '15.0.1'],
         'wheel'         : ['group': 'pypi', 'name': 'wheel',            'version': '0.26.0'],

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.groovy
@@ -79,11 +79,10 @@ class PythonPlugin implements Plugin<Project> {
          */
         project.dependencies.add(CONFIGURATION_BOOTSTRAP_REQS.value, settings.forcedVersions['virtualenv'])
 
-        project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['wheel'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['setuptools'])
+        project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['wheel'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['pip'])
         project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['setuptools-git'])
-        project.dependencies.add(CONFIGURATION_SETUP_REQS.value, settings.forcedVersions['pbr'])
 
         project.dependencies.add(CONFIGURATION_BUILD_REQS.value, settings.forcedVersions['flake8'])
         project.dependencies.add(CONFIGURATION_BUILD_REQS.value, settings.forcedVersions['Sphinx'])

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/DependencyOrder.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/DependencyOrder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.gradle.python.util;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+
+
+/**
+ * A container of static utilities for dependency order.
+ */
+public class DependencyOrder {
+    private DependencyOrder() {
+        // prevent instantiation of the utility class
+    }
+
+    /**
+     * Traverses the dependency tree post-order and collects dependencies.
+     * <p>
+     * The recursive post-order traversal returns the root of the (sub)tree.
+     * This allows the post-order adding into the set of dependencies as we
+     * return from the recursive calls. The set of seen dependencies ensures
+     * ensures that the cycles in Ivy metadata do not cause cycles in our
+     * recursive calls.
+     *
+     * @param root the root of the dependency (sub)tree
+     * @param seen the input set of already seen dependencies
+     * @param dependencies the output set of dependencies in post-order
+     * @return the root itself
+     */
+    public static ResolvedComponentResult postOrderDependencies(
+            ResolvedComponentResult root,
+            Set<ComponentIdentifier> seen,
+            Set<ResolvedComponentResult> dependencies) {
+        for (DependencyResult d : root.getDependencies()) {
+            if (!(d instanceof ResolvedDependencyResult)) {
+                throw new GradleException("Unresolved dependency found for " + d.toString());
+            }
+
+            ResolvedComponentResult component = ((ResolvedDependencyResult) d).getSelected();
+            ComponentIdentifier id = component.getId();
+
+            if (!seen.contains(id)) {
+                seen.add(id);
+                dependencies.add(postOrderDependencies(component, seen, dependencies));
+            }
+        }
+
+        return root;
+    }
+
+    /**
+     * Collects configuration dependencies in post-order.
+     *
+     * @param configuration Gradle configuration to work with
+     * @return set of resolved dependencies in post-order
+     */
+    public static Set<ResolvedComponentResult> configurationPostOrderDependencies(Configuration configuration) {
+        ResolvedComponentResult root = configuration.getIncoming().getResolutionResult().getRoot();
+        Set<ResolvedComponentResult> dependencies = new LinkedHashSet<>();
+        Set<ComponentIdentifier> seen = new HashSet<>();
+
+        postOrderDependencies(root, seen, dependencies);
+
+        return dependencies;
+    }
+
+    /**
+     * Collects configuration files in post-order.
+     *
+     * @param configuration Gradle configuration to work with
+     * @return set of files corresponding to post-order of dependency tree
+     */
+    public static Collection<File> configurationPostOrderFiles(Configuration configuration) {
+        Map<ModuleVersionIdentifier, File> idToFileMap = new HashMap<>();
+        Set<File> files = new LinkedHashSet<>();
+
+        // Create an id:file mapping.
+        Set<ResolvedArtifact> artifacts = configuration.getResolvedConfiguration().getResolvedArtifacts();
+        for (ResolvedArtifact artifact : artifacts) {
+            ModuleVersionIdentifier id = artifact.getModuleVersion().getId();
+            File file = artifact.getFile();
+            idToFileMap.put(id, file);
+        }
+
+        // Prepare an ordered set of files in post-order.
+        for (ResolvedComponentResult d : configurationPostOrderDependencies(configuration)) {
+            files.add(idToFileMap.get(d.getModuleVersion()));
+        }
+
+        // Check that the new set is the same size as the configuration file collection.
+        if (files.size() != configuration.getFiles().size()) {
+            throw new GradleException("Could not find matching dependencies for all configuration files");
+        }
+
+        return files;
+    }
+}

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/DependencyOrderTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/DependencyOrderTest.groovy
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.gradle.python.util
+
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.ResolvableDependencies
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.artifacts.ResolvedModuleVersion
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.artifacts.result.DependencyResult
+import org.gradle.api.artifacts.result.ResolutionResult
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.artifacts.result.UnresolvedDependencyResult
+import spock.lang.Specification
+
+
+/**
+ * Unit tests for DependencyOrder utility class.
+ */
+class DependencyOrderTest extends Specification {
+    static Configuration configuration
+    static ResolvedComponentResult root
+    static Set<ResolvedDependencyResult> rootDependencies
+    static ResolvedDependencyResult circularBranch
+    static Set<ResolvedComponentResult> expectedDependencies, expectedCircularBranch
+    static Set<File> configurationFiles, expectedFiles
+
+    /*
+     * Construct dependency tree with the index mapping to integers:
+     *
+     *               root
+     *                |
+     *        +-------+--------+- - - -+ the branch 4 used for
+     *       /        |         \       \    circular dependency
+     *      1         2          3       4       test
+     *     / \       /          /       / \
+     *    11 12     21         31      41 42
+     *        |    /  \                   / \
+     *       121  211 212                +--422
+     *
+     * Different types of mocks and stubs need to be constructed
+     * for the complex dependency and configuration types.
+     */
+    def setupSpec() {
+        def ids = [1, 11, 12, 121, 2, 21, 211, 212, 3, 31, 4, 41, 42, 422]
+        Map<Integer, ModuleVersionIdentifier> id = [:]
+        Map<Integer, LinkedHashSet<ResolvedDependencyResult>> dependencies = [:]
+        Map<Integer, ResolvedComponentResult> d = [:]
+        Map<Integer, ResolvedDependencyResult> r = [:]
+        Map<Integer, File> f = [:]
+        Map<Integer, ResolvedArtifact> a = [:]
+
+        for (int i : ids) {
+            // prepare module-version ids
+            id[i] = Mock(ModuleVersionIdentifier)
+
+            // prepare various types dependencies
+            dependencies[i] = new LinkedHashSet<ResolvedDependencyResult>()
+            d[i] = Stub(ResolvedComponentResult) {
+                getId() >> Mock(ComponentIdentifier)
+                getDependencies() >> dependencies[i]
+                getModuleVersion() >> id[i]
+            }
+            r[i] = Stub(ResolvedDependencyResult) {
+                getSelected() >> d[i]
+            }
+
+            // prepare files
+            f[i] = new File("f${i}")
+
+            // prepare artifacts
+            a[i] = Stub(ResolvedArtifact) {
+                getModuleVersion() >> Stub(ResolvedModuleVersion) {
+                    getId() >> id[i]
+                }
+                getFile() >> f[i]
+            }
+        }
+
+        // build dependency tree
+        dependencies[12].add(r[121])
+        dependencies[1].addAll([r[11], r[12]])
+        dependencies[21].addAll([r[211], r[212]])
+        dependencies[2].add(r[21])
+        dependencies[3].add(r[31])
+
+        // create circular dependency branch
+        dependencies[422].add(r[42])
+        dependencies[42].add(r[422])
+        dependencies[4].addAll(r[41], r[42])
+        circularBranch = r[4]
+
+        // prepare root using only the first three branches with no cycles
+        rootDependencies = new LinkedHashSet<ResolvedDependencyResult>([r[1], r[2], r[3]])
+        root = Stub(ResolvedComponentResult) {
+            getDependencies() >> rootDependencies
+        }
+        expectedDependencies = new LinkedHashSet<ResolvedComponentResult>(
+            [d[11], d[121], d[12], d[1], d[211], d[212], d[21], d[2], d[31], d[3]]
+        )
+        expectedCircularBranch = new LinkedHashSet<ResolvedComponentResult>([d[41], d[422], d[42], d[4]])
+
+        // prepare configurations
+        configurationFiles = new LinkedHashSet<File>(
+            [f[1], f[2], f[3], f[11], f[12], f[21], f[31], f[121], f[211], f[212]]
+        )
+        configuration = Stub(Configuration) {
+            getIncoming() >> Stub(ResolvableDependencies) {
+                getResolutionResult() >> Stub(ResolutionResult) {
+                    getRoot() >> root
+                }
+            }
+            getResolvedConfiguration() >> Stub(ResolvedConfiguration) {
+                getResolvedArtifacts() >> new LinkedHashSet<ResolvedArtifact>(
+                    [a[1], a[2], a[3], a[11], a[12], a[21], a[31], a[121], a[211], a[212]]
+                )
+            }
+            getFiles() >> configurationFiles
+        }
+        expectedFiles = new LinkedHashSet<File>(
+            [f[11], f[121], f[12], f[1], f[211], f[212], f[21], f[2], f[31], f[3]]
+        )
+    }
+
+    def "postOrderDependencies returns dependencies in post-order"() {
+        setup: "create sets"
+        def dependencies = new LinkedHashSet<ResolvedComponentResult>()
+        def seen = new HashSet<ComponentIdentifier>()
+
+        when: "called with root of depeendency tree"
+        DependencyOrder.postOrderDependencies(root, seen, dependencies)
+
+        then: "returns dependencies in post-order"
+        // comparing string representations because sets would match even with a wrong order
+        dependencies.toString() == expectedDependencies.toString()
+    }
+
+    def "postOrderDependencies handles circular dependencies well"() {
+        setup: "make the root with circular dependencies"
+        def dependencies = new LinkedHashSet<ResolvedComponentResult>()
+        def seen = new HashSet<ComponentIdentifier>()
+
+        // add the 4th branch for circular dependency test
+        expectedDependencies.addAll(expectedCircularBranch)
+        rootDependencies.add(circularBranch)
+
+        def root = Stub(ResolvedComponentResult) {
+            getDependencies() >> rootDependencies
+        }
+
+        when: "called with circular dependencies in the tree"
+        DependencyOrder.postOrderDependencies(root, seen, dependencies)
+
+        then: "returns dependencies in post-order cutting the recursion at the circular dependency"
+        // comparing string representations because sets would match even with a wrong order
+        dependencies.toString() == expectedDependencies.toString()
+
+        cleanup:
+        expectedDependencies.removeAll(expectedCircularBranch)
+        rootDependencies.remove(circularBranch)
+    }
+
+    def "postOrderDependencies throws an exception for unresolved dependency"() {
+        setup: "make the root with unresolved dependency"
+        def dependencies = new LinkedHashSet<ResolvedComponentResult>()
+        def seen = new HashSet<ComponentIdentifier>()
+
+        // create a set that can take both resolved and unresolved results
+        def branches = new LinkedHashSet<? extends DependencyResult>()
+        branches.addAll(rootDependencies)
+        branches.add(Mock(UnresolvedDependencyResult))
+
+        def root = Stub(ResolvedComponentResult) {
+            getDependencies() >> branches
+        }
+
+        when: "called with unresolved dependency in the tree"
+        DependencyOrder.postOrderDependencies(root, seen, dependencies)
+
+        then: "throws an exception"
+        thrown(GradleException)
+    }
+
+    def "configurationPostOrderDependencies returns post-order dependencies"() {
+        when: "called with configuration"
+        def dependencies = DependencyOrder.configurationPostOrderDependencies(configuration)
+
+        then: "dependencies are in post-order"
+        // comparing string representations because sets would match even with a wrong order
+        dependencies.toString() == expectedDependencies.toString()
+    }
+
+    def "configurationPostOrderFiles returns post-order files for dependencies"() {
+        when: "called with configuration"
+        def files = DependencyOrder.configurationPostOrderFiles(configuration)
+
+        then: "files are in post-order"
+        // comparing string representations because sets would match even with a wrong order
+        files.toString() == expectedFiles.toString()
+    }
+
+    def "configurationPostOrderFiles raises exception for non-matching size"() {
+        setup: "add unknown file to configuration"
+        File unknown = new File('fXXX')
+        configurationFiles.add(unknown)
+
+        when: "called with non-matching files size configuration"
+        DependencyOrder.configurationPostOrderFiles(configuration)
+
+        then: "throws an exception"
+        thrown(GradleException)
+
+        cleanup: "remove the unknown file"
+        configurationFiles.remove(unknown)
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 #version container
 #Tue May 02 21:46:02 UTC 2017
-version=0.4.10
+version=0.5.0


### PR DESCRIPTION
Add the new utility that resolves the dependencies in the post-order.
Use it to get a file collection and apply that collection to the
PipInstallTask and BuildWheelsTask for all configurations.

Now we can drop pbr from setup requirements.

Added comprehensive unit tests for the utility class.

Added additional assertions in an existing integration test.
Checked that it passed with expectation for sorted build dependencies on
master and that it failed with the same expectation with this change.
Once the condition was negated, it passed with this change.

Bumped the version to 0.5.0.