### PR TITLE
Prepare for upgrade of build and setup requirements.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
@@ -15,11 +15,12 @@
  */
 package com.linkedin.gradle.python.util
 
-import com.linkedin.gradle.python.PythonExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
+
+import com.linkedin.gradle.python.PythonExtension
 
 
 class PexFileUtil {
@@ -128,12 +129,22 @@ class PexFileUtil {
         List<String> reqs = []
 
         requirements.toString().split(System.getProperty("line.separator")).each {
-            def (String name, String version) = it.split('==')
+            List<String> parts = it.split('==')
+            String name = parts[0]
+            boolean editable = name.startsWith("-e ")
             // The tar name can have _ when package name has -, so check both.
-            if (!(developmentDependencies.contains(name)
+            if (!(editable || developmentDependencies.contains(name)
                 || developmentDependencies.contains(name.replace('-', '_')))) {
                 reqs.add(name)
             }
+        }
+
+        /*
+         * Starting with pip-9.x the current project will be editable in freeze.
+         * We need to add it unconditionally if it gets skipped above.
+         */
+        if (!reqs.contains(project.getName())) {
+            reqs.add(project.getName())
         }
 
         return reqs

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/FatPexGenerator.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/FatPexGenerator.java
@@ -15,23 +15,27 @@
  */
 package com.linkedin.gradle.python.util.internal.pex;
 
-import com.linkedin.gradle.python.util.EntryPointHelpers;
-import com.linkedin.gradle.python.util.PexFileUtil;
+import java.util.List;
+
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.process.ExecResult;
 
-import java.util.List;
+import com.linkedin.gradle.python.util.EntryPointHelpers;
+import com.linkedin.gradle.python.util.PexFileUtil;
+
 
 public class FatPexGenerator implements PexGenerator {
 
     private static final Logger logger = Logging.getLogger(FatPexGenerator.class);
 
     private final Project project;
+    private final List<String> pexOptions;
 
-    public FatPexGenerator(Project project) {
+    public FatPexGenerator(Project project, List<String> pexOptions) {
         this.project = project;
+        this.pexOptions = pexOptions;
     }
 
     @Override
@@ -44,7 +48,7 @@ public class FatPexGenerator implements PexGenerator {
             String name = PexFileUtil.createFatPexFilename(split[0].trim());
             String entry = split[1].trim();
 
-            PexExecSpecAction action = PexExecSpecAction.withEntryPoint(project, name, entry, dependencies);
+            PexExecSpecAction action = PexExecSpecAction.withEntryPoint(project, name, entry, pexOptions, dependencies);
             ExecResult exec = project.exec(action);
             new PexExecOutputParser(action, exec).validatePexBuildSuccessfully();
         }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
@@ -15,14 +15,6 @@
  */
 package com.linkedin.gradle.python.util.internal.pex;
 
-import com.linkedin.gradle.python.PythonExtension;
-import com.linkedin.gradle.python.util.ExtensionUtils;
-import com.linkedin.gradle.python.util.PackageInfo;
-import com.linkedin.gradle.python.util.StandardTextValues;
-import org.gradle.api.Action;
-import org.gradle.api.Project;
-import org.gradle.process.ExecSpec;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Collection;
@@ -30,6 +22,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.process.ExecSpec;
+
+import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.util.ExtensionUtils;
+import com.linkedin.gradle.python.util.PackageInfo;
+import com.linkedin.gradle.python.util.StandardTextValues;
 
 class PipFreezeAction {
 
@@ -70,7 +71,16 @@ class PipFreezeAction {
             }
         });
 
-        return PipFreezeOutputParser.getDependencies(developmentDependencies, requirements);
+        List<String> dependencies = PipFreezeOutputParser.getDependencies(developmentDependencies, requirements);
+        /*
+         * Starting with pip-9.x the current project will be editable in freeze.
+         * We need to add it unconditionally if it gets skipped in the parser.
+         */
+        if (!dependencies.contains(project.getName())) {
+            dependencies.add(project.getName());
+        }
+
+        return dependencies;
     }
 
     private static Set<String> configurationToSet(Project project, String configurationName) {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParser.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParser.java
@@ -34,11 +34,12 @@ class PipFreezeOutputParser {
         List<String> reqs = new ArrayList<>();
 
         // In regex world \n will also match the windows CR+LF
-        for (String it : requirements.split("\n")) {
-            String[] split = it.split("==");
-            String name = split[0];
+        for (String line : requirements.split("\n")) {
+            String[] parts = line.split("==");
+            String name = parts[0];
+            boolean editable = name.startsWith("-e ");
             // The tar name can have _ when package name has -, so check both.
-            if (!(ignoredDependencies.contains(name)
+            if (!(editable || ignoredDependencies.contains(name)
                 || ignoredDependencies.contains(name.replace("-", "_")))) {
                 reqs.add(name);
             }


### PR DESCRIPTION
Pex has changed the default behavior and does not allow pre-release
packages by default. That's a very noble goal, but it unfortunately
breaks a lot of builds. We are providing a task input (optional) that
allows us to pass additional options to the pex build task.

Pip has changed the format for the freeze. It now returns the currently
developed package as "-e repo-url-here" instead of "name==version". We
had to adapt to that change and put the current package name
unconditionally in.

Both changes were implemented in a way that will work with old or new
versions which opens a path for upgrades.