### PR TITLE
Fix pivy-importer.

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -35,16 +35,20 @@ task importRequiredDependencies(type: JavaExec) { task ->
     classpath = sourceSets.main.runtimeClasspath
     main = 'com.linkedin.python.importer.ImporterCLI'
 
-    def replacements = ['alabaster:0.7=alabaster:0.7.1', 'pytz:0a=pytz:2016.4', 'Babel:0.8=Babel:1.0',
-                        'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1', 'chardet:2.2=chardet:2.3.0',
-                        'setuptools:0.6a2=setuptools:19.1.1', 'idna:2.0.0=idna:2.0'].join(",")
+    def replacements = [
+        'alabaster:0.7=alabaster:0.7.1',                    // candidate for removal
+        'Babel:0.8=Babel:1.0',
+        'chardet:2.2=chardet:2.3.0',                        // candidate for removal
+        'idna:2.0.0=idna:2.0',                              // candidate for removal
+        'pytz:0a=pytz:2016.4',                              // candidate for removal
+        'pytz:2004b.2=pytz:2016.4',
+        'setuptools:0.6a2=setuptools:19.1.1',               // candidate for removal
+        'setuptools:0.6c1=setuptools:19.1.1',
+        'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1',      // candidate for removal
+    ].join(",")
     def packagesToInclude = [
-        'appdirs:1.4.3',
-        'docutils:0.12',
-        'flake8:2.4.0',
         'flake8:2.5.4',
         'Flask:0.11.1',
-        'packaging:16.8',
         'pbr:1.8.0',
         'pex:1.1.4',
         'pip:7.1.2',
@@ -59,7 +63,9 @@ task importRequiredDependencies(type: JavaExec) { task ->
         'virtualenv:15.0.1',
         'wheel:0.26.0',
     ].join(" ")
-    def forceDeps = ['docutils:0.12'].join(',')
+    def forceDeps = [
+        'docutils:0.12',
+    ].join(',')
     args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements --force $forceDeps".split(' ')
 
     outputs.dir(getIvyRepo())

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/ImporterCLI.java
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/ImporterCLI.java
@@ -48,7 +48,7 @@ public class ImporterCLI {
         CommandLineParser parser = new DefaultParser();
         CommandLine line = parser.parse(options, args);
 
-        if (line.hasOption("quite")) {
+        if (line.hasOption("quiet")) {
             Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
             root.setLevel(Level.WARN);
         }
@@ -68,7 +68,8 @@ public class ImporterCLI {
 
         Set<String> processedDependencies = new HashSet<>();
         for (String dependency : line.getArgList()) {
-            DependencyDownloader dependencyDownloader = new DependencyDownloader(dependency, repoPath, replacements);
+            DependencyDownloader dependencyDownloader = new DependencyDownloader(
+                    dependency, repoPath, replacements, line.hasOption("latest"), line.hasOption("pre"));
             dependencyDownloader.getProcessedDependencies().addAll(processedDependencies);
             dependencyDownloader.download();
             processedDependencies.addAll(dependencyDownloader.getProcessedDependencies());
@@ -105,8 +106,8 @@ public class ImporterCLI {
             .valueSeparator(',')
             .build();
 
-        Option quite = Option.builder()
-            .longOpt("quite")
+        Option quiet = Option.builder()
+            .longOpt("quiet")
             .numberOfArgs(0)
             .desc("Sets logging level to WARN")
             .build();
@@ -118,11 +119,26 @@ public class ImporterCLI {
             .valueSeparator(',')
             .build();
 
+        Option latest = Option.builder()
+            .longOpt("latest")
+            .numberOfArgs(0)
+            .desc("Gets latest versions of dependencies")
+            .build();
+
+        Option pre = Option.builder()
+            .longOpt("pre")
+            .numberOfArgs(0)
+            .desc("Allows pre-releases (alpha, beta, release candidates)")
+            .build();
+
         Options options = new Options();
         options.addOption(replacement);
         options.addOption(repo);
-        options.addOption(quite);
+        options.addOption(quiet);
         options.addOption(force);
+        options.addOption(latest);
+        options.addOption(pre);
+
         return options;
     }
 

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencyDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencyDownloader.groovy
@@ -34,10 +34,15 @@ class DependencyDownloader {
     PypiApiCache cache = new PypiApiCache()
     File ivyRepoRoot
     DependencySubstitution dependencySubstitution
+    boolean latestVersions
+    boolean allowPreReleases
 
-    DependencyDownloader(String project, File ivyRepoRoot, DependencySubstitution dependencySubstitution) {
+    DependencyDownloader(String project, File ivyRepoRoot, DependencySubstitution dependencySubstitution,
+                         boolean latestVersions, boolean allowPreReleases) {
         this.dependencySubstitution = dependencySubstitution
         this.ivyRepoRoot = ivyRepoRoot
+        this.latestVersions = latestVersions
+        this.allowPreReleases = allowPreReleases
         dependencies.add(project)
     }
 
@@ -69,7 +74,8 @@ class DependencyDownloader {
         destDir.mkdirs()
 
         def artifact = downloadArtifact(destDir, sdistDetails.url)
-        def packageDependencies = new SourceDistPackage(artifact, cache, dependencySubstitution).dependencies
+        def packageDependencies = new SourceDistPackage(artifact, cache, dependencySubstitution,
+                                                        latestVersions, allowPreReleases).dependencies
 
         new IvyFileWriter(name, version, [sdistDetails], packageDependencies).writeIvyFile(destDir)
 

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/VersionRange.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/VersionRange.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.python.importer.pypi
+
+
+class VersionRange {
+    String startVersion
+    boolean includeStart
+    String endVersion
+    boolean includeEnd
+
+    VersionRange(String startVersion, boolean includeStart, String endVersion, boolean includeEnd) {
+        this.startVersion = startVersion
+        this.includeStart = includeStart
+        this.endVersion = endVersion
+        this.includeEnd = includeEnd
+    }
+
+    private static List<Integer> numericVersion(String release) {
+        def v = []
+        for (String s : release.split(/\./)) {
+            if (s.isInteger()) {
+                v.add(s as Integer)
+            } else {
+                def m = s =~ /(\d+)(.+?)(\d*)/
+                if (m.matches()) {
+                    v.add(m.group(1) as Integer)
+                    /*
+                     * Put negative marker for rc, alpha, beta, keeping the order for letters.
+                     * The tilda (~) is the last ASCII letter.
+                     */
+                    v.add(m.group(2).toCharArray()[0] - '~'.toCharacter() - 1)
+                    if (m.group(3).isInteger()) {
+                        v.add(m.group(3) as Integer)
+                    }
+                }
+            }
+        }
+        return v
+    }
+
+    static int compareVersions(String r1, String r2) {
+        def v1 = numericVersion(r1)
+        def v2 = numericVersion(r2)
+        /*
+         * A version with the same numbers as another is larger than an alpha, beta,
+         * or release candidate.
+         */
+        def i = 0
+        while (i < v1.size() && i < v2.size()) {
+            if (v1[i] > v2[i]) {
+                return 1
+            } else if (v2[i] > v1[i]) {
+                return -1
+            }
+            i++
+        }
+        if (v1.size() == v2.size()) {
+            return 0
+        } else if (i < v2.size()) {
+            return (v2[i] < 0) ? 1 : -1
+        }
+        return (v1[i] < 0) ? -1 : 1
+    }
+
+}


### PR DESCRIPTION
The importer didn't handle conditions with not equal, greater than, or
less than correctly. It also didn't look into the ranges of
dependencies. This fixes the parsing of conditions, and provides for
avoiding the pre-releases (default) beside sorting them correctly below
stable releases. It also adds the option to use latest versions of
dependencies instead of lowest, which is important for the case when a
requirement is greater than some very old release.