### PR TITLE
Remove duplicate code path for building pex.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonWebApplicationPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonWebApplicationPlugin.groovy
@@ -15,16 +15,16 @@
  */
 package com.linkedin.gradle.python.plugin
 
-import com.linkedin.gradle.python.extension.DeployableExtension
-import com.linkedin.gradle.python.extension.PexExtension
-import com.linkedin.gradle.python.extension.WheelExtension
-import com.linkedin.gradle.python.tasks.BuildWebAppTask
-import com.linkedin.gradle.python.util.ExtensionUtils
-import com.linkedin.gradle.python.util.StandardTextValues
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
+
+import com.linkedin.gradle.python.extension.DeployableExtension
+import com.linkedin.gradle.python.tasks.BuildWebAppTask
+import com.linkedin.gradle.python.util.ExtensionUtils
+import com.linkedin.gradle.python.util.StandardTextValues
+
 
 class PythonWebApplicationPlugin extends PythonBasePlugin {
 
@@ -40,8 +40,6 @@ class PythonWebApplicationPlugin extends PythonBasePlugin {
         project.plugins.apply(PythonPexDistributionPlugin)
 
         DeployableExtension deployableExtension = ExtensionUtils.maybeCreateDeployableExtension(project)
-        WheelExtension wheelExtension = ExtensionUtils.maybeCreateWheelExtension(project)
-        PexExtension pexExtension = ExtensionUtils.maybeCreatePexExtension(project)
 
         /**
          * Build a gunicorn pex file.
@@ -53,10 +51,6 @@ class PythonWebApplicationPlugin extends PythonBasePlugin {
         project.tasks.create(TASK_BUILD_WEB_APPLICATION, BuildWebAppTask) { task ->
             task.description = 'Build a web app, by default using gunicorn, but it\'s configurable.'
             task.dependsOn(TASK_BUILD_PEX)
-            task.deployableExtension = deployableExtension
-            task.wheelExtension = wheelExtension
-            task.pexExtension = pexExtension
-            task.pythonInterpreter = settings.details.systemPythonInterpreter.path
             task.executable = new File(deployableExtension.deployableBinDir, "gunicorn")
             task.entryPoint = GUNICORN_ENTRYPOINT
         }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PexFileUtil.groovy
@@ -15,13 +15,6 @@
  */
 package com.linkedin.gradle.python.util
 
-import org.gradle.api.GradleException
-import org.gradle.api.Project
-import org.gradle.process.ExecResult
-import org.gradle.process.ExecSpec
-
-import com.linkedin.gradle.python.PythonExtension
-
 
 class PexFileUtil {
 
@@ -29,143 +22,7 @@ class PexFileUtil {
         //private constructor for util class
     }
 
-    /**
-     * Build a pex file.
-     *
-     * @param project The project to run <code>pex</code> within.
-     * @param pexCache The directory to use for pex's build cache.
-     * @param pexName The name to use for the output pex file.
-     * @param repoDir The repository (usually a wheel-cache) to use to build the pex file.
-     * @param pexShebang The explicit shebang line to be prepended to the resulting pex file.
-     * @param entryPoint The entry point to burn into the pex file, or <code>null</code> if no entry point should be used.
-     */
-    public static void buildPexFile(Project project, File pexCache, String pexName, File repoDir, String pexShebang, String entryPoint) {
-        PythonExtension settings = project.getExtensions().getByType(PythonExtension)
-        def arguments = []
-        arguments << '--no-pypi'
-        arguments << '--cache-dir' << pexCache.absolutePath
-        arguments << '--output-file' << pexName
-        arguments << '--repo' << repoDir.absolutePath
-        arguments << '--python-shebang' << pexShebang
-        if (entryPoint) {
-            arguments << '--entry-point' << entryPoint
-        }
-        new ByteArrayOutputStream().withStream { output ->
-            ExecResult buildPexResult = project.exec { ExecSpec execSpec ->
-                execSpec.environment settings.pythonEnvironment
-                execSpec.standardOutput = output
-                execSpec.errorOutput = output
-                execSpec.ignoreExitValue = true
-                execSpec.commandLine([
-                    settings.details.getVirtualEnvInterpreter(),
-                    settings.details.getVirtualEnvironment().getPex(),
-                    *arguments,
-                    *pipFreeze(project),
-                ])
-            }
-            if (buildPexResult.exitValue != 0) {
-                def outputString = output.toString().trim()
-                println(outputString)
-                def packageMatcher = (outputString =~ /(?s).*Could not satisfy all requirements for ([\w.-]+):.*/)
-                def packageName = "<see output above>"
-                if (packageMatcher.matches()) {
-                    packageName = packageMatcher[0][1]
-                }
-
-                throw new GradleException(
-                    """
-                    | Failed to build a pex file (see output above)!
-                    |
-                    | This typically happens because your virtual environment contains a cached copy of ${packageName}
-                    | that no other package depends on any more.
-                    | Usually, this is the result of updating a package that used to depend on ${packageName}.
-                    |
-                    | Another possible reason is that you started using a newer version of Python
-                    | without checking if all the libraries you use are compatible.
-                    | If you can find the missing package in the output above with the message
-                    | [EXCLUDED], then it works only with lower versions of Python.
-                    """.stripMargin().stripIndent()
-                )
-
-            }
-        }
-    }
-
-    /**
-     * Run ``pip freeze`` and return the results.
-     *
-     * TODO: Make this configurable with other users 'special cases'
-     *
-     * @param project The project to run ``pip freeze`` within.
-     * @return A list of requirements that looks like ['-r', 'requests', '-r', ...].
-     */
-    @SuppressWarnings("UnusedVariable")
-    static List<String> pipFreeze(Project project) {
-        PythonExtension settings = project.getExtensions().getByType(PythonExtension)
-
-        // Setup requirements, build, and test dependencies
-        Set<String> developmentDependencies = configurationToSet(project.configurations.setupRequires.files)
-        developmentDependencies.addAll(configurationToSet(project.configurations.build.files))
-        developmentDependencies.addAll(configurationToSet(project.configurations.test.files))
-        developmentDependencies.removeAll(configurationToSet(project.configurations.python.files))
-
-        if (settings.details.pythonVersion.pythonMajorMinor == '2.6' && developmentDependencies.contains('argparse')) {
-            developmentDependencies.remove('argparse')
-        }
-
-        ByteArrayOutputStream requirements = new ByteArrayOutputStream()
-
-        project.exec {
-            environment settings.pythonEnvironment
-            commandLine([
-                settings.details.getVirtualEnvInterpreter(),
-                settings.details.getVirtualEnvironment().getPip(),
-                'freeze',
-                '--disable-pip-version-check',
-            ])
-            standardOutput requirements
-        }
-
-        List<String> reqs = []
-
-        requirements.toString().split(System.getProperty("line.separator")).each {
-            List<String> parts = it.split('==')
-            String name = parts[0]
-            boolean editable = name.startsWith("-e ")
-            // The tar name can have _ when package name has -, so check both.
-            if (!(editable || developmentDependencies.contains(name)
-                || developmentDependencies.contains(name.replace('-', '_')))) {
-                reqs.add(name)
-            }
-        }
-
-        /*
-         * Starting with pip-9.x the current project will be editable in freeze.
-         * We need to add it unconditionally if it gets skipped above.
-         */
-        if (!reqs.contains(project.getName())) {
-            reqs.add(project.getName())
-        }
-
-        return reqs
-    }
-
-    /**
-     * Convert a collection of files into a set of names.
-     *
-     * @param files The set of files to add to the set.
-     * @return A set of names.
-     */
-    private static Set<String> configurationToSet(Collection<File> files) {
-        Set<String> configNames = new HashSet<String>()
-        for (File file : files) {
-            def packageInfo = PackageInfo.fromPath(file.name)
-            configNames.add(packageInfo.name)
-        }
-        return configNames
-    }
-
-    public static String createThinPexFilename(String name) {
+    static String createThinPexFilename(String name) {
         if (OperatingSystem.current().isWindows()) {
             return name + ".py"
         } else {
@@ -173,7 +30,7 @@ class PexFileUtil {
         }
     }
 
-    public static String createFatPexFilename(String name) {
+    static String createFatPexFilename(String name) {
         if (OperatingSystem.current().isWindows()) {
             return name + ".py"
         } else {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/FatPexGenerator.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/FatPexGenerator.java
@@ -48,9 +48,18 @@ public class FatPexGenerator implements PexGenerator {
             String name = PexFileUtil.createFatPexFilename(split[0].trim());
             String entry = split[1].trim();
 
-            PexExecSpecAction action = PexExecSpecAction.withEntryPoint(project, name, entry, pexOptions, dependencies);
-            ExecResult exec = project.exec(action);
-            new PexExecOutputParser(action, exec).validatePexBuildSuccessfully();
+            buildEntryPoint(name, entry, dependencies);
         }
+    }
+
+    public void buildEntryPoint(String name, String entry, List<String> pipFreezeDependencies) {
+        List<String> dependencies = pipFreezeDependencies;
+        // When called from outside buildEntryPoints above, this can be null
+        if (dependencies == null) {
+             dependencies = new PipFreezeAction(project).getDependencies();
+        }
+        PexExecSpecAction action = PexExecSpecAction.withEntryPoint(project, name, entry, pexOptions, dependencies);
+        ExecResult exec = project.exec(action);
+        new PexExecOutputParser(action, exec).validatePexBuildSuccessfully();
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecOutputParser.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecOutputParser.java
@@ -15,13 +15,14 @@
  */
 package com.linkedin.gradle.python.util.internal.pex;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.process.ExecResult;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 class PexExecOutputParser {
 
@@ -47,10 +48,10 @@ class PexExecOutputParser {
         String packageName = "<see output above>";
 
         logger.lifecycle(outputFromPexCommand);
-        Pattern pattern = Pattern.compile("(?s).*Could not satisfy all requirements for ([\\w\\-]+):.*");
+        Pattern pattern = Pattern.compile("(?s).*Could not satisfy all requirements for ([\\w.-]+):.*");
         Matcher matcher = pattern.matcher(outputFromPexCommand);
         if (matcher.matches()) {
-            packageName = matcher.group(0);
+            packageName = matcher.group(1);
         }
 
         String lineSeperator = System.getProperty("line.separator");


### PR DESCRIPTION
Use only the new generator code.
The old utility functions are removed and their calls refactored.
Tested on a build of a web app, with or without fat pex.

Fixed the bug in the regex and match group used in the new
PexExecOutputParser, based on the correct code in the old utility
function. Tested on a real build with an artifically introduced error
that the error report contains only the package name, instead of the
whole match sentence.