### PR TITLE
Upgrade setup and build requirements for Python 3.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,3 @@ PyGradle works on the following platforms.
 Additional compatibility notes are availabe [here](docs/compatibility.md).
 We're happy to review and merge pull requests that add support for additional
 platforms.
-
-# Known Potential Issues
-
-- Due to a bug in pip, when trying to install scipy may fail. A potential work
-around is to use a newer version of pip. A PR was merged into pip master that
-fixes the issue (https://github.com/pypa/pip/pull/3701), a version of pip with
-the fix in it has not been released yet. If this is an issue for your org, you
-could release a version of pip with this fix in it. For more details on the
-change and issues please review https://github.com/pypa/pip/pull/3701 and
-https://github.com/pypa/pip/pull/3079

--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -47,24 +47,24 @@ task importRequiredDependencies(type: JavaExec) { task ->
         'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1',      // candidate for removal
     ].join(",")
     def packagesToInclude = [
-        'flake8:2.5.4',
-        'Flask:0.11.1',
+        'flake8:2.6.2',
+        'Flask:0.12.2',
         'pbr:1.8.0',
-        'pex:1.1.4',
-        'pip:7.1.2',
-        'pytest-cov:2.2.1',
-        'pytest-xdist:1.14',
-        'pytest:2.9.1',
-        'requests:2.10.0',
-        'setuptools-git:1.1',
-        'setuptools:19.1.1',
+        'pex:1.2.7',
+        'pip:9.0.1',
+        'pytest:3.0.3',
+        'pytest-cov:2.4.0',
+        'pytest-xdist:1.15.0',
+        'requests:2.18.1',
+        'setuptools:33.1.1',
+        'setuptools-git:1.2',
         'six:1.10.0',
         'Sphinx:1.4.1',
-        'virtualenv:15.0.1',
-        'wheel:0.26.0',
+        'virtualenv:15.1.0',
+        'wheel:0.29.0',
     ].join(" ")
     def forceDeps = [
-        'docutils:0.12',
+        'setuptools:33.1.1',
     ].join(',')
     args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements --force $forceDeps".split(' ')
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -65,18 +65,19 @@ class PythonExtension {
 
     /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
-        'argparse'      : ['group': 'pypi', 'name': 'argparse',         'version': '1.4.0'],
-        'flake8'        : ['group': 'pypi', 'name': 'flake8',           'version': '2.5.4'],
-        'pex'           : ['group': 'pypi', 'name': 'pex',              'version': '1.1.4'],
-        'pip'           : ['group': 'pypi', 'name': 'pip',              'version': '7.1.2'],
-        'pytest'        : ['group': 'pypi', 'name': 'pytest',           'version': '2.9.1'],
-        'pytest-cov'    : ['group': 'pypi', 'name': 'pytest-cov',       'version': '2.2.1'],
-        'pytest-xdist'  : ['group': 'pypi', 'name': 'pytest-xdist',     'version': '1.14'],
-        'setuptools'    : ['group': 'pypi', 'name': 'setuptools',       'version': '19.1.1'],
-        'setuptools-git': ['group': 'pypi', 'name': 'setuptools-git',   'version': '1.1'],
-        'Sphinx'        : ['group': 'pypi', 'name': 'Sphinx',           'version': '1.4.1'],
-        'virtualenv'    : ['group': 'pypi', 'name': 'virtualenv',       'version': '15.0.1'],
-        'wheel'         : ['group': 'pypi', 'name': 'wheel',            'version': '0.26.0'],
+        'argparse': ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
+        'flake8': ['group': 'pypi', 'name': 'flake8', 'version': '2.6.2'],
+        'pex': ['group': 'pypi', 'name': 'pex', 'version': '1.2.7'],
+        'pip': ['group': 'pypi', 'name': 'pip', 'version': '9.0.1'],
+        'pytest': ['group': 'pypi', 'name': 'pytest', 'version': '3.0.3'],
+        'pytest-cov': ['group': 'pypi', 'name': 'pytest-cov', 'version': '2.4.0'],
+        'pytest-xdist': ['group': 'pypi', 'name': 'pytest-xdist', 'version': '1.15.0'],
+        'setuptools': ['group': 'pypi', 'name': 'setuptools', 'version': '33.1.1'],
+        'setuptools-git': ['group': 'pypi', 'name': 'setuptools-git', 'version': '1.2'],
+        'six': ['group': 'pypi', 'name': 'six', 'version': '1.10.0'],
+        'Sphinx': ['group': 'pypi', 'name': 'Sphinx', 'version': '1.4.1'],
+        'virtualenv': ['group': 'pypi', 'name': 'virtualenv', 'version': '15.1.0'],
+        'wheel': ['group': 'pypi', 'name': 'wheel', 'version': '0.29.0'],
     ]
 
     /* Container of the details related to the venv/python instance */

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 #version container
 #Wed Jun 07 22:23:02 UTC 2017
-version=0.5.7
+version=0.6.0


### PR DESCRIPTION
With previously committed changes we now have everything in place for
upgrade of setuptools, virtualenv, pip, and pex. We also upgrade pytest
and flake8 to match versions used internally at LinkedIn.

Also, bumped the version to 0.6.0 and removed the issue with pip-7
because we now use pip-9 with our patch applied
(https://github.com/pypa/pip/pull/3701).