### PR TITLE
process arguments to pytest properly. Fixes #147

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -49,6 +49,8 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
 
     FileTree sources;
     private List<String> arguments = new ArrayList<>();
+    // similar to additionalArguments, but not overridable by user's build script
+    private List<String> subArguments = new ArrayList<>();
     private PythonExtension component;
     private PythonDetails pythonDetails;
     private String output;
@@ -112,6 +114,14 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
         arguments.addAll(args);
     }
 
+    public void subArgs(String... args) {
+        subArguments.addAll(Arrays.asList(args));
+    }
+
+    public void subArgs(Collection<String> args) {
+        subArguments.addAll(args);
+    }
+
     @TaskAction
     public void executePythonProcess() {
         preExecution();
@@ -124,7 +134,11 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
                 execSpec.environment(getComponent().pythonEnvironment);
                 execSpec.environment(getComponent().pythonEnvironmentDistgradle);
                 execSpec.commandLine(getPythonDetails().getVirtualEnvInterpreter());
+                // arguments are passed to the python interpreter
                 execSpec.args(arguments);
+                // subArguments are arguments for previous arguments. eg: arguments to py.test like -k
+                execSpec.args(subArguments);
+                // additionalArguments are same as subArguments, but are expected from user's build script
                 execSpec.args(additionalArguments);
                 execSpec.setIgnoreExitValue(ignoreExitValue);
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
@@ -50,7 +50,8 @@ class PyCoverageTask extends PyTestTask {
      * Include coverage data
      */
     public void preExecution() {
-        extraArgs.addAll(
+        // using subArgs as these must be added after py.test
+        subArgs(
             '--cov',
             project.file(component.srcDir).getAbsolutePath(),
             '--cov-report=xml',

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyTestTask.groovy
@@ -28,10 +28,8 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
     private static final int NO_TESTS_COLLECTED_ERRNO = 5
     private static final String NO_TEST_WARNING = "***** WARNING: You did not write any tests! *****"
 
-    /** specific test file was given and only the tests in that file should be executed */
-    boolean specificFileGiven = false
-    /** extra args for subclasses, such as coverage */
-    List<String> extraArgs = []
+    // specific test file was given and only the tests in that file should be executed
+    private boolean specificFileGiven = false
 
     PyTestTask() {
         ignoreExitValue = true
@@ -39,13 +37,11 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
 
     @Override
     public void preExecution() {
-            args(pythonDetails.virtualEnvironment.findExecutable("py.test").absolutePath)
-            if (extraArgs != []) {
-                args(extraArgs)
-            }
-            if (!specificFileGiven) {
-                args(component.testDir)
-            }
+        // any arguments to pytest(-k, -s etc..) must go into subArgs to get appended after py.test
+        args(pythonDetails.virtualEnvironment.findExecutable("py.test").absolutePath)
+        if (!specificFileGiven) {
+            args(component.testDir)
+        }
     }
 
     @Override
@@ -65,17 +61,17 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
     @Option(option = "file", description = "Only run tests on the input file")
     public void filterFiles(String file) {
         specificFileGiven = true
-        args(file)
+        subArgs(file)
     }
 
     /**
-     * Only test one file
+     * Only run tests matching given substring expression
      *
-     * @param testName name of the tests to be executed
+     * @param testSubstringExpression name of the tests to be executed
      */
-    @Option(option = "test-name", description = "Only run tests matching description")
-    public void filterTestCase(String testName) {
-        args('-k', testName)
+    @Option(option = "test-substring", description = "Only run tests matching the given substring")
+    public void filterTestCase(String testSubStringExpression) {
+        subArgs('-k', testSubStringExpression)
     }
 
     /**
@@ -86,7 +82,17 @@ class PyTestTask extends AbstractPythonTestSourceDefaultTask {
     @Option(option = "enable-console", description = "Enables console output")
     public void enableConsole(boolean enabled) {
         if (enabled) {
-            args('-s')
+            subArgs('-s')
         }
+    }
+
+    /**
+     * Only run tests matching given mark expression
+     *
+     * @param markExpression
+     */
+    @Option(option = "mark-expression", description = "only run tests matching given mark expression")
+    public void filterMarker(String markExpression) {
+        subArgs('-m', markExpression)
     }
 }


### PR DESCRIPTION
* provide subArgs() method to add subArguments in subclasses.
* keep additionalArguments as is to not break the current Inputs API.
* remove extraArgs in PyTestTask is it's redundant and confusing
* make the api simpler. use args() to add arguments to python interpreter. And use subArgs() to pass arguments to arguments.
* add --mark-expression option for pytest -m
