### PR TITLE
Pass explicit requirements to pex generation

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/FatPexGenerator.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/FatPexGenerator.java
@@ -17,6 +17,7 @@ package com.linkedin.gradle.python.util.internal.pex;
 
 import java.util.List;
 
+import java.util.Map;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -40,7 +41,7 @@ public class FatPexGenerator implements PexGenerator {
 
     @Override
     public void buildEntryPoints() {
-        List<String> dependencies = new PipFreezeAction(project).getDependencies();
+        Map<String, String> dependencies = new PipFreezeAction(project).getDependencies();
 
         for (String it : EntryPointHelpers.collectEntryPoints(project)) {
             logger.lifecycle("Processing entry point: {}", it);
@@ -52,8 +53,8 @@ public class FatPexGenerator implements PexGenerator {
         }
     }
 
-    public void buildEntryPoint(String name, String entry, List<String> pipFreezeDependencies) {
-        List<String> dependencies = pipFreezeDependencies;
+    public void buildEntryPoint(String name, String entry, Map<String, String> pipFreezeDependencies) {
+        Map<String, String> dependencies = pipFreezeDependencies;
         // When called from outside buildEntryPoints above, this can be null
         if (dependencies == null) {
              dependencies = new PipFreezeAction(project).getDependencies();

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecSpecAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecSpecAction.java
@@ -18,9 +18,11 @@ package com.linkedin.gradle.python.util.internal.pex;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import java.util.Map;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.process.ExecSpec;
@@ -42,7 +44,7 @@ class PexExecSpecAction implements Action<ExecSpec> {
     private final File pexShebang;
     private final String entryPoint;
     private final List<String> pexOptions;
-    private final List<String> dependencies;
+    private final Map<String, String> dependencies;
     private final ByteArrayOutputStream outputStream;
 
     /**
@@ -56,7 +58,7 @@ class PexExecSpecAction implements Action<ExecSpec> {
      * @param dependencies The dependencies that are needed for this pex
      */
     private PexExecSpecAction(PythonExtension pythonExtension, File pexCache, File outputFile, File wheelCache,
-                              File pexShebang, String entryPoint, List<String> pexOptions, List<String> dependencies) {
+                              File pexShebang, String entryPoint, List<String> pexOptions, Map<String, String> dependencies) {
         this.pythonExtension = pythonExtension;
         this.pexCache = pexCache;
         this.outputFile = outputFile;
@@ -86,7 +88,7 @@ class PexExecSpecAction implements Action<ExecSpec> {
         }
 
         execSpec.args(pexOptions);
-        execSpec.args(dependencies);
+        execSpec.args(pexRequirements(dependencies));
 
         execSpec.setStandardOutput(outputStream);
         execSpec.setErrorOutput(outputStream);
@@ -107,7 +109,7 @@ class PexExecSpecAction implements Action<ExecSpec> {
      * @return an instance of PexExecSpecAction to build a pex
      */
     public static PexExecSpecAction withEntryPoint(
-            Project project, String pexName, String entryPoint, List<String> pexOptions, List<String> dependencies) {
+            Project project, String pexName, String entryPoint, List<String> pexOptions, Map<String, String> dependencies) {
         PythonExtension pythonExtension = ExtensionUtils.getPythonExtension(project);
         PexExtension pexExtension = ExtensionUtils.getPythonComponentExtension(project, PexExtension.class);
         WheelExtension wheelExtension = ExtensionUtils.getPythonComponentExtension(project, WheelExtension.class);
@@ -132,7 +134,7 @@ class PexExecSpecAction implements Action<ExecSpec> {
      * @return an instance of PexExecSpecAction to build a pex
      */
     public static PexExecSpecAction withOutEntryPoint(
-            Project project, String pexName, List<String> pexOptions, List<String> dependencies) {
+            Project project, String pexName, List<String> pexOptions, Map<String, String> dependencies) {
         PythonExtension pythonExtension = ExtensionUtils.getPythonExtension(project);
         PexExtension pexExtension = ExtensionUtils.getPythonComponentExtension(project, PexExtension.class);
         WheelExtension wheelExtension = ExtensionUtils.getPythonComponentExtension(project, WheelExtension.class);
@@ -146,5 +148,13 @@ class PexExecSpecAction implements Action<ExecSpec> {
             null,
             pexOptions,
             dependencies);
+    }
+
+    private List<String> pexRequirements(Map<String, String> dependencies) {
+        List<String> requirements = new ArrayList<>();
+        for (Map.Entry<String, String> entry : dependencies.entrySet()) {
+            requirements.add(entry.getKey() + "==" + entry.getValue());
+        }
+        return requirements;
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
@@ -19,7 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -40,7 +40,7 @@ class PipFreezeAction {
         this.project = project;
     }
 
-    public List<String> getDependencies() {
+    public Map<String, String> getDependencies() {
         final PythonExtension settings = ExtensionUtils.getPythonExtension(project);
 
         // Setup requirements, build, and test dependencies
@@ -71,15 +71,9 @@ class PipFreezeAction {
             }
         });
 
-        List<String> dependencies = PipFreezeOutputParser.getDependencies(developmentDependencies, requirements);
-        /*
-         * Starting with pip-9.x the current project will be editable in freeze.
-         * We need to add it unconditionally if it gets skipped in the parser.
-         */
-        if (!dependencies.contains(project.getName())) {
-            dependencies.add(project.getName());
-        }
-
+        Map<String, String> dependencies = PipFreezeOutputParser.getDependencies(developmentDependencies, requirements);
+        // for snapshot builds, wheel gets built with _SNAPSHOT(where as it's -SNAPSHOT in gradle land), and the version becomes <semver>._SNAPSHOT
+        dependencies.put(project.getName(), project.getVersion().toString().replace("-SNAPSHOT", "_SNAPSHOT"));
         return dependencies;
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/ThinPexGenerator.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/ThinPexGenerator.java
@@ -60,7 +60,7 @@ public class ThinPexGenerator implements PexGenerator {
         DeployableExtension deployableExtension = ExtensionUtils.getPythonComponentExtension(
                 extension, DeployableExtension.class);
 
-        List<String> dependencies = new PipFreezeAction(project).getDependencies();
+        Map<String, String> dependencies = new PipFreezeAction(project).getDependencies();
 
         PexExecSpecAction action = PexExecSpecAction.withOutEntryPoint(
                 project, project.getName(), pexOptions, dependencies);


### PR DESCRIPTION
* Collect requirement versions along with names(previous implementation) and
  generate pex with exact versions of each requirement
* transform the version string of current project from -SNAPSHOT to _SNAPSHOT as
  the wheel is generated with _SNAPSHOT suffix for snapshot builds
* Throw GradleException if pip freeze requirements are not exact
* update tests