### PR TITLE
Second attempt at default and whitelist Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In particular, you're going to have to:
 - Decide how you want to distribute a custom setuptools distribution class.
 - Author your build.gradle file.
 
-These decisions and tasks shouldn't take to long for you finish, but they are
+These decisions and tasks shouldn't take too long for you finish, but they are
 required. A deeper dive into what it takes to get started, how you can use our
 demonstrative Artifactory instance, and a few project examples is available in
 our detailed [getting started](docs/getting-started.md) guide.

--- a/docs/plugins/python.md
+++ b/docs/plugins/python.md
@@ -62,3 +62,28 @@ PyGradle will automatically disable tasks if certain conditions are present.
 * coverage will skip if the configured `python.testDir` doesn't exist
 * flake8 will skip if both `python.testDir` and `python.srcDir` doesn't exist
 * both Sphinx Documentation tasks will skip if the configured `python.docsDir` doesn't exist
+
+## Default and allowed Python version
+This plugin enforces a set of default and allowed Python versions.  For
+example, you can specify `pythonVersion = '3'` and you will get whatever the
+default Python 3 version is.  Similarly `pythonVersion = '2'` gets you
+whatever the default Python 2 version is.
+
+This plugin also enforces a set of allowed Python versions.  If you choose a
+Python version that is not allowed, you will see an error messages such as:
+
+```
+> Python 3.2 not allowed; choose from [2.6, 2.7, 3.4, 3.5, 3.6]
+```
+
+If you see this error message, you must adjust your `pythonVersion` setting to
+one of the allowed values.
+
+Consumers of this extension can change the default Python 2, Python 3, and
+allowed versions by making a call on the `PythonDetails` object, either the
+one returned by `PythonExtension.getDetails()` or on any `PythonDetails`
+instance you create, e.g. in Groovy:
+
+```groovy
+pythonDetails.setPythonDefaultVersions('2.7', '3.6', ['2.7', '3.5', '3.6'])
+```

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -62,7 +62,6 @@ class PythonExtension {
     /** Settings that can be put into the pip.conf file in the venv */
     public Map<String, Map<String, String>> pipConfig = [:]
 
-
     /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
         'argparse': ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
@@ -161,5 +160,3 @@ class PythonExtension {
         this.pinnedFile = pinnedFile
     }
 }
-
-

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersions.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersions.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.extension;
+
+import java.util.Collection;
+import java.util.TreeSet;
+import org.gradle.api.GradleException;
+
+
+public class PythonDefaultVersions {
+    private final String defaultPython2Version;
+    private final String defaultPython3Version;
+    private final Collection<String> allowedVersions;
+
+    public PythonDefaultVersions(String defaultPython2, String defaultPython3, Collection<String> allowedVersions) {
+        defaultPython2Version = defaultPython2;
+        defaultPython3Version = defaultPython3;
+        this.allowedVersions = allowedVersions;
+    }
+
+    public PythonDefaultVersions(Collection<String> allowedVersions) {
+        defaultPython2Version = "2.6";
+        defaultPython3Version = "3.5";
+        this.allowedVersions = allowedVersions;
+    }
+
+    public PythonDefaultVersions(String defaultPython2, String defaultPython3) {
+        this(defaultPython2, defaultPython3, new TreeSet<String>());
+    }
+
+    public PythonDefaultVersions() {
+        this(new TreeSet<String>());
+    }
+
+    public String normalize(String version) {
+        if (version.equals("2")) {
+            return defaultPython2Version;
+        }
+        if (version.equals("3")) {
+            return defaultPython3Version;
+        }
+        if (allowedVersions.isEmpty()) {
+            // All versions are allowed.
+            return version;
+        }
+        if (!allowedVersions.contains(new PythonVersion(version).getPythonMajorMinor())) {
+            throw new GradleException(
+                "Python " + version + " is not allowed; choose from " + allowedVersions
+                + "\nSee https://github.com/linkedin/pygradle/blob/master/docs/plugins/python.md"
+                + "#default-and-allowed-python-version");
+        }
+        return version;
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDetails.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
 import java.io.File;
 import java.io.Serializable;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.List;
 
 
@@ -35,6 +36,7 @@ public class PythonDetails implements Serializable {
     private File pythonInterpreter;
     private String virtualEnvPrompt;
     private PythonVersion pythonVersion;
+    private PythonDefaultVersions pythonDefaultVersions;
     private OperatingSystem operatingSystem = OperatingSystem.current();
 
     private List<File> searchPath;
@@ -50,6 +52,7 @@ public class PythonDetails implements Serializable {
         searchPath = operatingSystem.getPath();
         venvOverride = venvDir;
         this.virtualEnvironment = new VirtualEnvironment(this);
+        pythonDefaultVersions = new PythonDefaultVersions();
     }
 
     private void updateFromPythonInterpreter() {
@@ -114,16 +117,21 @@ public class PythonDetails implements Serializable {
         searchPath.add(file);
     }
 
-    public void setPythonVersion(String pythonVersion) {
-        if ("2".equals(pythonVersion)) {
-            pythonVersion = "2.6";
-        }
+    public void setPythonDefaultVersions(PythonDefaultVersions defaults) {
+        pythonDefaultVersions = defaults;
+    }
 
-        if ("3".equals(pythonVersion)) {
-            pythonVersion = "3.5";
-        }
+    public void setPythonDefaultVersions(String defaultPython2, String defaultPython3, Collection<String> allowedVersions) {
+        pythonDefaultVersions = new PythonDefaultVersions(defaultPython2, defaultPython3, allowedVersions);
+    }
 
-        pythonInterpreter = operatingSystem.findInPath(searchPath, operatingSystem.getExecutableName(String.format("python%s", pythonVersion)));
+    public PythonDefaultVersions getPythonDefaultVersions() {
+        return pythonDefaultVersions;
+    }
+
+    public void setPythonVersion(String version) {
+        version = pythonDefaultVersions.normalize(version);
+        pythonInterpreter = operatingSystem.findInPath(searchPath, operatingSystem.getExecutableName(String.format("python%s", version)));
         updateFromPythonInterpreter();
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonVersion.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonVersion.java
@@ -17,6 +17,7 @@ package com.linkedin.gradle.python.extension;
 
 import java.io.Serializable;
 
+
 public class PythonVersion implements Serializable {
 
     private final String version;

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersionsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersionsTest.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.extension
+
+import org.gradle.api.GradleException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class PythonDefaultVersionsTest extends Specification {
+    @Unroll
+    def 'accept any version #a by default normalized to #b'() {
+        expect:
+        new PythonDefaultVersions().normalize(a) == b
+
+        where:
+        a       || b
+        '1.5.2' || '1.5.2'
+        '2'     || '2.6'
+        '3'     || '3.5'
+    }
+
+    @Unroll
+    def 'explicit Python default versions #a #b normalize #c to #d'() {
+        expect:
+        new PythonDefaultVersions(a, b).normalize(c) == d
+
+        where:
+        a     | b     | c   || d
+        '2.8' | '3.0' | '2' || '2.8'
+        '2.8' | '3.0' | '3' || '3.0'
+    }
+
+    @Unroll
+    def 'test acceptable #a normalizes to #b'() {
+        expect:
+        new PythonDefaultVersions(['2.7', '3.5', '3.6']).normalize(a) == b
+
+        where:
+        a     || b
+        '3.5' || '3.5'
+        '2.7' || '2.7'
+        '3'   || '3.5'
+        '2'   || '2.6'
+    }
+
+    @Unroll
+    def 'test unacceptable #a'() {
+        when:
+        new PythonDefaultVersions(['2.7', '3.5', '3.6']).normalize(a)
+
+        then:
+        def e = thrown(GradleException)
+        e.message == (
+            'Python ' + a + ' is not allowed; choose from [2.7, 3.5, 3.6]\n' +
+            'See https://github.com/linkedin/pygradle/blob/master/docs/plugins/python.md#default-and-allowed-python-version')
+
+        where:
+        a     | _
+        '2.5' | _
+        '3.2' | _
+    }
+
+    @Unroll
+    def 'test acceptable #a normalizes to #b with defaults Py2: #c and Py3: #d'() {
+        expect:
+        new PythonDefaultVersions(c, d, ['2.7', '3.5', '3.6']).normalize(a) == b
+
+        where:
+        a   | c     | d     || b
+        '3' | '2.7' | '3.6' || '3.6'
+        '2' | '2.7' | '3.6' || '2.7'
+    }
+
+    @Unroll
+    def 'test acceptable #a normalizes to #b with whitelist #c'() {
+        expect:
+        new PythonDefaultVersions('2.6', '3.5', c).normalize(a) == b
+
+        where:
+        a     | c                            || b
+        '3.5' | ['2.7', '3.5', '3.6']        || '3.5'
+        '3.7' | ['2.7', '3.5', '3.6', '3.7'] || '3.7'
+    }
+
+    @Unroll
+    def 'test unacceptable #a with whitelist #b'() {
+        when:
+        new PythonDefaultVersions('2.6', '3.5', b).normalize(a)
+
+        then:
+        def e = thrown(GradleException)
+        e.message == (
+            'Python ' + a + ' is not allowed; choose from ' + b +
+            '\nSee https://github.com/linkedin/pygradle/blob/master/docs/plugins/python.md#default-and-allowed-python-version')
+
+        where:
+        a     | b
+        '2.6' | ['2.7', '3.5', '3.6']
+        '3.5' | ['2.7', '3.6']
+    }
+}

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDetailsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDetailsTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.extension
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+
+class PythonDetailsTest extends Specification {
+
+    def project = new ProjectBuilder().build()
+    def details = new PythonDetails(project)
+
+    /* Most of the work is done by the PythonDefaultVersions class, so see
+       that class and tests.  We'd like to be able to completely test
+       PythonDetails.setPythonVersion() too, but that's currently impossible,
+       since that method searches for a Python interpreter on the file system
+       matching the selected version.  We can't guarantee that such a Python
+       version will exist so we can't test it without perhaps some mocking of
+       operatingSystem.findInPath() , which I haven't been able to come up
+       with yet.
+
+       It does seem like this one can be tested though.
+     */
+    def 'test set to unacceptable version'() {
+        when:
+        details.setPythonDefaultVersions(new PythonDefaultVersions(['2.7', '3.5', '3.6']))
+        details.setPythonVersion('2.5')
+
+        then:
+        thrown(GradleException)
+    }
+}

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonVersionTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonVersionTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.extension
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class PythonVersionTest extends Specification {
+
+    @Unroll
+    def 'get #a Python version'() {
+        expect:
+        new PythonVersion(a).getPythonVersion() == a
+
+        where:
+        a        || _
+        '2.7.11' || _
+        '3.5.2'  || _
+    }
+
+    @Unroll
+    def 'test #a major minor #b'() {
+        expect:
+        new PythonVersion(a).getPythonMajorMinor() == b
+
+        where:
+        a        || b
+        '2.7.11' || '2.7'
+        '3.5.2'  || '3.5'
+    }
+
+    @Unroll
+    def 'test #a major #b'() {
+        expect:
+        new PythonVersion(a).getPythonMajor() == b
+
+        where:
+        a        || b
+        '2.7.11' || '2'
+        '3.5.2'  || '3'
+    }
+
+    @Unroll
+    def 'test #a minor #b'() {
+        expect:
+        new PythonVersion(a).getPythonMinor() == b
+
+        where:
+        a        || b
+        '2.7.11' || '7'
+        '3.5.2'  || '5'
+    }
+
+    @Unroll
+    def 'test #a patch #b'() {
+        expect:
+        new PythonVersion(a).getPythonPatch() == b
+
+        where:
+        a        || b
+        '2.7.11' || '11'
+        '3.5.2'  || '2'
+    }
+}


### PR DESCRIPTION
Support a configurable set of default and allowed Python versions.

* Add the PythonDefaultsVersions class which maintains the default Python 2
  and 3 versions.  This allows a product to say it supports just '2' or '3'
  and it will automatically get the Python 2.x or 3.x default version.

  This class also maintains a collection of allowed Major.Minor versions,
  and implements a `normalize()` method that enforces this set.  If a selected
  Python version falls outside this set, a GradleException is thrown.

* The PythonDetails class is augmented to allow for setting and getting the
  PythonDefaultsVersions instance, and it calls the `normalize()` method in
  its `setPythonVersion()` method.  This completes the enforcement.

* Also fix a documentation typo, and describe how to use the new default and
  allowed Python versions feature.
