### PR TITLE
Fix handling of package versions in wheels.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeAction.java
@@ -72,8 +72,8 @@ class PipFreezeAction {
         });
 
         Map<String, String> dependencies = PipFreezeOutputParser.getDependencies(developmentDependencies, requirements);
-        // for snapshot builds, wheel gets built with _SNAPSHOT(where as it's -SNAPSHOT in gradle land), and the version becomes <semver>._SNAPSHOT
-        dependencies.put(project.getName(), project.getVersion().toString().replace("-SNAPSHOT", "_SNAPSHOT"));
+        // The version will convert - into _ for wheel builds, so convert right here to handle -SNAPSHOT, -MPDEP, ...
+        dependencies.put(project.getName(), project.getVersion().toString().replace("-", "_"));
         return dependencies;
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParser.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParser.java
@@ -39,12 +39,16 @@ class PipFreezeOutputParser {
             if (!line.startsWith("-e ")) {  // ignore editable requirements
                 String[] parts = line.split("==");
                 if (parts.length != 2) {
-                    throw new GradleException("unsupported requirement format. expected: <requirement>==<version>. found: " + line);
+                    throw new GradleException("Unsupported requirement format. expected: <requirement>==<version>. found: " + line);
                 }
                 String name = parts[0];
-                // The tar name can have _ when package name has -, so check both.
+                String version = parts[1];
+                /*
+                 * The tar name can have _ when package name has -, so check both.
+                 * The version will convert - into _ for wheel builds, so convert right here.
+                 */
                 if (!(ignoredDependencies.contains(name) || ignoredDependencies.contains(name.replace("-", "_")))) {
-                    reqs.put(name, parts[1]);
+                    reqs.put(name, version.replace("-", "_"));
                 }
             }
         }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParserTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/internal/pex/PipFreezeOutputParserTest.groovy
@@ -48,18 +48,19 @@ class PipFreezeOutputParserTest extends Specification {
             |snowballstemmer==1.1.0
             |Sphinx==1.4.1
             |testProject==unspecified
+            |MP==1.2.3-MPDEP
             |wheel==0.26.0'''.stripMargin().stripIndent()
 
         expect:
         PipFreezeOutputParser.getDependencies(['pbr', 'Babel', 'pep8', 'py', 'setuptools', 'pytest-xdist', 'Jinja2', 'flake8', 'snowballstemmer',
                                                'alabaster', 'sphinx_rtd_theme', 'Pygments', 'pytest-cov', 'pip', 'mccabe', 'docutils', 'coverage', 'pex',
                                                'six', 'setuptools-git', 'pyflakes', 'pytest', 'wheel', 'imagesize', 'argparse', 'Sphinx', 'colorama',
-                                               'pytz'], freezeOutput) == ['testProject': 'unspecified']
+                                               'pytz'], freezeOutput) == ['testProject': 'unspecified', 'MP': '1.2.3_MPDEP']
 
         PipFreezeOutputParser.getDependencies(['pbr', 'Babel', 'pep8', 'py', 'setuptools', 'pytest-xdist', 'Jinja2', 'flake8', 'snowballstemmer',
                                                'alabaster', 'sphinx_rtd_theme', 'Pygments', 'pip', 'mccabe', 'docutils', 'coverage', 'pex',
                                                'six', 'setuptools-git', 'pyflakes', 'pytest', 'wheel', 'imagesize', 'argparse', 'Sphinx', 'colorama',
-                                               'pytz'], freezeOutput) == ['testProject': 'unspecified', 'pytest-cov': '2.2.1']
+                                               'pytz'], freezeOutput) == ['testProject': 'unspecified', 'MP': '1.2.3_MPDEP', 'pytest-cov': '2.2.1']
     }
 
     def 'throws error on bad requirements format'() {
@@ -71,6 +72,6 @@ class PipFreezeOutputParserTest extends Specification {
 
         then:
         def e = thrown(GradleException)
-        e.message.startsWith("unsupported requirement format")
+        e.message.startsWith("Unsupported requirement format")
     }
 }


### PR DESCRIPTION
The versions that contains hyphens, such as "1.2.3-SNAPSHOT" or
"1.2.3-MPDEP" or "1.2.3-dev-linkedin" get converted into strings with
underscores "_" instead of hyphens "-". This fix takes care of
converting them correctly before passing them to pex for build.