### PR TITLE
Support importing libraries that have .tgz as extension

### DIFF
--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/SourceDistPackage.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/SourceDistPackage.groovy
@@ -151,7 +151,7 @@ class SourceDistPackage {
     }
 
     private String getRequiresTextFile() {
-        if (packageFile.absolutePath.contains('.tar.')) {
+        if (packageFile.absolutePath.contains('.tar.') || packageFile.absolutePath.endsWith('.tgz')) {
             return explodeTarForRequiresText()
         } else {
             return explodeZipForRequiresText()
@@ -166,7 +166,6 @@ class SourceDistPackage {
         }
         return ''
     }
-
 
     private String explodeTarForRequiresText() {
         TarArchiveInputStream tarIn = explodeArtifact()
@@ -191,7 +190,7 @@ class SourceDistPackage {
         BufferedInputStream inputStream = new BufferedInputStream(fin)
         InputStream compressorInputStream
 
-        if (packageFile.absolutePath.endsWith('.gz')) {
+        if (packageFile.absolutePath.endsWith('.gz') || packageFile.absolutePath.endsWith('.tgz')) {
             compressorInputStream = new GzipCompressorInputStream(inputStream)
         } else if (packageFile.absolutePath.endsWith('.bz2')) {
             compressorInputStream = new BZip2CompressorInputStream(inputStream)


### PR DESCRIPTION
This fixes the import of python libraries that use .tgz instead of .tar.gz as extension. An example of this is dill 2.4.0.