### PR TITLE
Ensure packaging order is correct.

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonWebApplicationPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonWebApplicationPluginIntegrationTest.groovy
@@ -69,7 +69,8 @@ class PythonWebApplicationPluginIntegrationTest extends Specification {
         result.task(':foo:pytest').outcome == TaskOutcome.SUCCESS
         result.task(':foo:check').outcome == TaskOutcome.SUCCESS
         result.task(':foo:build').outcome == TaskOutcome.SUCCESS
-        result.task(':foo:packageWebApplication').outcome == TaskOutcome.SUCCESS
+        result.task(':foo:packageDeployable').outcome == TaskOutcome.SUCCESS
+        result.task(':foo:packageWebApplication').outcome == TaskOutcome.SKIPPED
         Path deployablePath = testProjectDir.getRoot().toPath().resolve(Paths.get('foo', 'build', 'deployable', 'bin'))
 
         when: "we have a pex file"

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonFlyerPlugin.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonFlyerPlugin.groovy
@@ -89,8 +89,8 @@ class PythonFlyerPlugin implements Plugin<Project> {
             }
         }
 
-        project.tasks.getByName(StandardTextValues.TASK_INSTALL_PROJECT.value).dependsOn(project.tasks.getByName(TASK_SETUP_RESOURCE_LINK))
-
+        project.tasks.getByName(StandardTextValues.TASK_INSTALL_PROJECT.value)
+            .dependsOn(project.tasks.getByName(TASK_SETUP_RESOURCE_LINK))
 
         /*
          * In order to make the resource files accessible when deploying the project, we need to copy the
@@ -98,14 +98,14 @@ class PythonFlyerPlugin implements Plugin<Project> {
          */
         project.tasks.create(name: TASK_PACKAGE_RESOURCE_FILES, type: Copy) { Copy copy ->
             def deployableExtension = ExtensionUtils.maybeCreateDeployableExtension(project)
-            copy.dependsOn(project.tasks['buildWebApplication'])
+            copy.dependsOn(project.tasks.getByName(PythonWebApplicationPlugin.TASK_BUILD_WEB_APPLICATION))
 
             copy.from resourceConf
             copy.into "${deployableExtension.deployableBuildDir}/resource"
         }
 
-
         // Make sure we've copied all the files before running the task: packageDeployable
-        project.tasks.getByName(PythonWebApplicationPlugin.TASK_PACKAGE_WEB_APPLICATION).dependsOn(project.tasks.getByName(TASK_PACKAGE_RESOURCE_FILES))
+        project.tasks.getByName(PythonPexDistributionPlugin.TASK_PACKAGE_DEPLOYABLE)
+            .dependsOn(project.tasks.getByName(TASK_PACKAGE_RESOURCE_FILES))
     }
 }


### PR DESCRIPTION
We must execute the packaging after all building is completed.
Also, let's avoid double packaging and use a single packaging task for
all product types.