### PR TITLE
Add cliName (the LHS of setup.py entry_points) to the environment via templates.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildPexTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildPexTask.java
@@ -53,9 +53,10 @@ import com.linkedin.gradle.python.util.pex.EntryPointTemplateProvider;
  * allowing the task to customize the entry point.
  *
  * The template that is provided will be rendered using a {@link groovy.text.SimpleTemplateEngine}, and will have two
- * properties passed to it automatically. They are named <code>realPex</code>, gives the name of the pex to execute against
- * and <code>entryPoint</code> which is the name of the entry point. If you wish to provide your own template, with more
- * options they can be added to {@link BuildPexTask#additionalProperties} and they will be provided to the template engine.
+ * properties passed to it automatically. They are named <code>realPex</code>, gives the name of the pex to execute against,
+ * <code>cliName</code>, which is the name of your script (the left-hand-side in setup.py), and <code>entryPoint</code> which
+ * is the name of the entry point. If you wish to provide your own template, with more options they can be added to
+ * {@link BuildPexTask#additionalProperties} and they will be provided to the template engine.
  *
  * The pexOptions allow passing of additional options to the pex command, such as '--pre' to allow pre-release packages.
  * This is useful because the default behavior changed in pex-1.2.0 without bumping of major version.

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/ThinPexGenerator.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/ThinPexGenerator.java
@@ -79,6 +79,7 @@ public class ThinPexGenerator implements PexGenerator {
             propertyMap.putAll(extraProperties);
             propertyMap.put("realPex", PexFileUtil.createThinPexFilename(project.getName()));
             propertyMap.put("entryPoint", entry);
+            propertyMap.put("cliName", name);
 
             DefaultTemplateProviderOptions providerOptions = new DefaultTemplateProviderOptions(project, extension, entry);
             new EntryPointWriter(project, templateProvider.retrieveTemplate(providerOptions))

--- a/pygradle-plugin/src/main/resources/templates/pex_cli_entrypoint.py.template
+++ b/pygradle-plugin/src/main/resources/templates/pex_cli_entrypoint.py.template
@@ -10,7 +10,7 @@ def main():
     tool_dir = os.path.dirname(os.path.realpath(__file__))
     pex_exec = os.path.join(tool_dir, '$realPex')
     os.environ.update(
-        dict(PEX_MODULE='$entryPoint')
+        dict(CLI_NAME='$cliName', PEX_MODULE='$entryPoint')
     )
     os.execve(pex_exec, sys.argv, os.environ)
 

--- a/pygradle-plugin/src/main/resources/templates/pex_non_cli_entrypoint.sh.template
+++ b/pygradle-plugin/src/main/resources/templates/pex_non_cli_entrypoint.sh.template
@@ -1,3 +1,3 @@
 #!/bin/bash
 [ -z "\$BASEDIR" ] && BASEDIR=\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )/.." && pwd )
-exec /usr/bin/env PEX_ROOT="\$BASEDIR/libexec" PEX_MODULE="${entryPoint}" \$BASEDIR/bin/${realPex} "\$@"
+exec /usr/bin/env CLI_NAME="${cliName}" PEX_ROOT="\$BASEDIR/libexec" PEX_MODULE="${entryPoint}" \$BASEDIR/bin/${realPex} "\$@"


### PR DESCRIPTION
This will allow PEX based CLI programs to get their name from the environment, skipping expensive pkg_resources loading & iteration.