### PR TITLE
Fix the download of packages with markers.

### DIFF
--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/SourceDistPackage.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/SourceDistPackage.groovy
@@ -81,8 +81,18 @@ class SourceDistPackage {
                     line = line.replaceAll(' ', '')
                 }
 
-                List<String> conditions = line.split(',')
-                log.debug("Split({}) {}", line, conditions)
+                /*
+                 * Newer versions of setuptools allow use of markers in
+                 * install_requires. Previously they were allowed only
+                 * in extras_require and appeared only in separate config
+                 * section in the metadata. We need to parse for markers
+                 * in the default section now too.
+                 */
+                List<String> lineWithMarker = line.split(';')
+                log.debug("Split({}) {}", line, lineWithMarker)
+
+                List<String> conditions = lineWithMarker[0].split(',')
+                log.debug("Split({}) {}", lineWithMarker[0], conditions)
 
                 String packageName = conditions[0].split(/!=|==|[><]=?/)[0]
                 VersionRange range = new VersionRange('', false, '', false)


### PR DESCRIPTION
Adapt pivy-importer to the new marker metadata allowed in
install_requires, and thus in the default config section in the sdist
metadata.

Fixes issue #187.