### PR TITLE
Fixing issue with CI when resolves dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
         group = 'CI'
         doLast {
             //noinspection GroovyAssignabilityCheck
-            configurations.each { conf ->
+            configurations.findAll { it.isCanBeResolved() }.each { conf ->
                 conf.files
             }
         }


### PR DESCRIPTION
With the Gradle 4.x upgrade, you can't resolve some configurations. This
change makes it so we won't resolve configurations that aren't
resolveable