### PR TITLE
Adding Wheel Filtering Support

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/WheelFirstPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/WheelFirstPlugin.java
@@ -25,6 +25,8 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.tasks.TaskContainer;
 
 import java.io.File;
@@ -50,6 +52,9 @@ public class WheelFirstPlugin implements Plugin<Project> {
 
             SupportedWheelFormats supportedWheelFormats = new SupportedWheelFormats();
             FileBackedWheelCache wheelCache = new FileBackedWheelCache(cacheDir, supportedWheelFormats);
+
+            ExtensionContainer extensionContainer = ((ExtensionAware) ExtensionUtils.getPythonExtension(project)).getExtensions();
+            extensionContainer.add("wheelCache", wheelCache);
 
             FindAbiForCurrentPythonTask abiScript = tasks.create("findPythonAbi", FindAbiForCurrentPythonTask.class, it -> {
                 it.dependsOn(tasks.getByName(TASK_VENV_CREATE.getValue()));

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/EmptyWheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/EmptyWheelCache.java
@@ -19,8 +19,30 @@ import com.linkedin.gradle.python.extension.PythonDetails;
 
 import java.io.File;
 import java.util.Optional;
+import java.util.function.Function;
 
 public class EmptyWheelCache implements WheelCache {
+
+    @Override
+    public void addVersionFilter(Function<String, Boolean> filter) {
+        //No work to do here.
+    }
+
+    @Override
+    public boolean isWheelForVersionCacheable(String version) {
+        return false;
+    }
+
+    @Override
+    public void addDependencyFilter(Function<String, Boolean> filter) {
+
+    }
+
+    @Override
+    public boolean isWheelForDependencyCacheable(String dependencyName) {
+        return false;
+    }
+
     @Override
     public Optional<File> findWheel(String library, String version, PythonDetails pythonDetails) {
         return Optional.empty();

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/WheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/WheelCache.java
@@ -20,7 +20,42 @@ import com.linkedin.gradle.python.extension.PythonDetails;
 import java.io.File;
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.function.Function;
 
 public interface WheelCache extends Serializable {
+    /**
+     * A filter will prevent a Cache Hit when the {@link Function} returns true.
+     *
+     * This is useful if you want to exclude pre-release/chaning builds from using the cache.
+     *
+     * @param filter returning true, will prevent version from matching in the cache.
+     */
+    void addVersionFilter(Function<String, Boolean> filter);
+
+    /**
+     * Given that we have versions that can be filtered, we should also prevent wheels from being built for them.
+     *
+     * @param version version to check for.
+     * @return true when the cacheable wheel should be built.
+     */
+    boolean isWheelForVersionCacheable(String version);
+
+    /**
+     * A filter will prevent a Cache Hit when the {@link Function} returns true.
+     *
+     * This is useful if you want to exclude pre-release/chaning builds from using the cache.
+     *
+     * @param filter returning true, will prevent version from matching in the cache.
+     */
+    void addDependencyFilter(Function<String, Boolean> filter);
+
+    /**
+     * If a dependency shouldn't have a wheel built, then we don't want to build wheels for it either.
+     *
+     * @param dependencyName Dependency Name
+     * @return true, when the cacheable wheel should be built.
+     */
+    boolean isWheelForDependencyCacheable(String dependencyName);
+
     Optional<File> findWheel(String library, String version, PythonDetails pythonDetails);
 }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCacheTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCacheTest.groovy
@@ -36,4 +36,29 @@ class FileBackedWheelCacheTest extends Specification {
         expect:
         cache.findWheel('Sphinx', '1.6.3', pythonExec).isPresent()
     }
+
+    def 'will skip version that are excluded'() {
+        def wheelCache = temporaryFolder.newFolder('wheel-cache')
+        def formats = new SupportedWheelFormats()
+        def pythonExec = temporaryFolder.newFile('python')
+        formats.addSupportedAbi(new AbiDetails(pythonExec, 'py2', 'none', 'any'))
+        FileBackedWheelCache cache = new FileBackedWheelCache(wheelCache, formats)
+        cache.addVersionFilter({ it -> true })
+
+        new File(wheelCache, 'Sphinx-1.6.3-py2.py3-none-any.whl').createNewFile()
+
+        expect:
+        !cache.findWheel('Sphinx', '1.6.3', pythonExec).isPresent()
+    }
+
+    def 'will handle null version'() {
+        def wheelCache = temporaryFolder.newFolder('wheel-cache')
+        def pythonExec = temporaryFolder.newFile('python')
+        def formats = new SupportedWheelFormats()
+        FileBackedWheelCache cache = new FileBackedWheelCache(wheelCache, formats)
+
+
+        expect:
+        !cache.findWheel('Sphinx', null, pythonExec).isPresent()
+    }
 }


### PR DESCRIPTION
Sometimes, wheels should be skipped from caching. This is because we
don't want to re-use dependencies that can change, as they won't be
re-built afterwards.