### PR TITLE
Upgrade the unit tests to use new fromPath method.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PackageInfo.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PackageInfo.groovy
@@ -75,7 +75,7 @@ class PackageInfo {
             return new PackageInfo(packagePath, filename, null)
         }
 
-        if (packagePath.getPath() == packageName) {
+        if (packagePath.getName() == packageName) {
             throw new GradleException("Cannot calculate Python package extension from ${ packagePath } using regular expression /${ extensionRegex }/.")
         }
 

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageInfoTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageInfoTest.groovy
@@ -22,7 +22,7 @@ class PackageInfoTest extends Specification {
 
     def 'can parse boring sdist'() {
         when:
-        def packageInfo = PackageInfo.fromPath('foo-1.0.0.tar.gz')
+        def packageInfo = packageInGradleCache('foo-1.0.0.tar.gz')
         then:
         assert packageInfo.name == 'foo'
         assert packageInfo.version == '1.0.0'
@@ -30,7 +30,7 @@ class PackageInfoTest extends Specification {
 
     def 'can parse snapshot sdist'() {
         when:
-        def packageInfo = PackageInfo.fromPath('foo-1.0.0-SNAPSHOT.tar.gz')
+        def packageInfo = packageInGradleCache('foo-1.0.0-SNAPSHOT.tar.gz')
         then:
         assert packageInfo.name == 'foo'
         assert packageInfo.version == '1.0.0-SNAPSHOT'
@@ -38,7 +38,7 @@ class PackageInfoTest extends Specification {
 
     def 'can parse a sdist that has "-" characters in the packageInfo.name'() {
         when:
-        def packageInfo = PackageInfo.fromPath('foo-bar-1.0.0.tar.gz')
+        def packageInfo = packageInGradleCache('foo-bar-1.0.0.tar.gz')
         then:
         assert packageInfo.name == 'foo-bar'
         assert packageInfo.version == '1.0.0'
@@ -46,7 +46,7 @@ class PackageInfoTest extends Specification {
 
     def 'can parse a sdist that has "-" characters in the packageInfo.version'() {
         when:
-        def packageInfo = PackageInfo.fromPath('foo-1.0.0-linkedin1.tar.gz')
+        def packageInfo = packageInGradleCache('foo-1.0.0-linkedin1.tar.gz')
         then:
         assert packageInfo.name == 'foo'
         assert packageInfo.version == '1.0.0-linkedin1'
@@ -54,7 +54,7 @@ class PackageInfoTest extends Specification {
 
     def 'can parse a sdist from a absolute path'() {
         when:
-        def packageInfo = PackageInfo.fromPath('/Users/sholsapp/.gradle/caches/modules-2/files-2.1/pypi/pex/0.8.5/5802dfe6dde45790e8a3e6f98f4f94219320f904/pex-0.8.5.tar.gz')
+        def packageInfo = packageInGradleCache('/Users/sholsapp/.gradle/caches/modules-2/files-2.1/pypi/pex/0.8.5/5802dfe6dde45790e8a3e6f98f4f94219320f904/pex-0.8.5.tar.gz')
         then:
         assert packageInfo.name == 'pex'
         assert packageInfo.version == '0.8.5'
@@ -62,16 +62,30 @@ class PackageInfoTest extends Specification {
 
     def 'can parse a windows path'() {
         when:
-        def packageInfo = PackageInfo.fromPath('Z:\\pygradle\\build\\ivy-repo\\pypi\\setuptools\\19.1.1\\setuptools-19.1.1')
+        def packageInfo = packageInGradleCache('Z:\\pygradle\\build\\ivy-repo\\pypi\\setuptools\\19.1.1\\setuptools-19.1.1')
         then:
         assert packageInfo.name == 'setuptools'
         assert packageInfo.version == '19.1.1'
     }
 
-    def 'can not parse a sdist that has an unknown extension'() {
+    def 'can not parse an sdist that has an unknown extension'() {
         when:
-        PackageInfo.fromPath('foo-1.0.0.xxx')
+        packageInGradleCache('foo-1.0.0.xxx')
         then:
         thrown(GradleException)
     }
+
+    // TODO: Remove this test completely when we drop the deprecated method.
+    def 'still supports deprecated fromPath method'() {
+        when:
+        def packageInfo = PackageInfo.fromPath('foo-1.0.0.tgz')
+        then:
+        packageInfo.name == 'foo'
+        packageInfo.version == '1.0.0'
+    }
+
+    static PackageInfo packageInGradleCache(String name) {
+        return PackageInfo.fromPath(new File("/foo/.gradle/caches/", name))
+    }
+
 }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageSettingsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageSettingsTest.groovy
@@ -26,63 +26,67 @@ class PackageSettingsTest extends Specification {
 
     def "default package settings environment"() {
         expect: "empty environment"
-        packageSettings.getEnvironment(PackageInfo.fromPath('flake8-1.2.3.tar.gz')) == [:]
+        packageSettings.getEnvironment(packageInGradleCache('flake8-1.2.3.tar.gz')) == [:]
     }
 
     def "default package settings global options"() {
         expect: "empty global options"
-        packageSettings.getGlobalOptions(PackageInfo.fromPath('Sphinx-1.2.3.tar.gz')) == []
+        packageSettings.getGlobalOptions(packageInGradleCache('Sphinx-1.2.3.tar.gz')) == []
     }
 
     def "default package settings install options"() {
         expect: "empty install options for non-project package that is not a snapshot"
-        packageSettings.getInstallOptions(PackageInfo.fromPath('requests-1.2.3.tar.gz')) == []
+        packageSettings.getInstallOptions(packageInGradleCache('requests-1.2.3.tar.gz')) == []
     }
 
     def "package settings install options for snapshot"() {
         expect: "install option --ignore-installed for SNAPSHOT packages to enforce re-install"
-        packageSettings.getInstallOptions(PackageInfo.fromPath('requests-1.2.3-SNAPSHOT.tar.gz')) == [
+        packageSettings.getInstallOptions(packageInGradleCache('requests-1.2.3-SNAPSHOT.tar.gz')) == [
             '--ignore-installed']
     }
 
     def "package settings install options for project snapshot()"() {
         expect: "project snapshot does not use --ignore-installed because it's installed editable"
-        packageSettings.getInstallOptions(PackageInfo.fromPath('foo-1.2.3-SNAPSHOT.tar.gz')) == []
+        packageSettings.getInstallOptions(packageInGradleCache('foo-1.2.3-SNAPSHOT.tar.gz')) == []
     }
 
     def "default package settings build options"() {
         expect: "empty build options"
-        packageSettings.getBuildOptions(PackageInfo.fromPath('numpy-1.2.3.tar.gz')) == []
+        packageSettings.getBuildOptions(packageInGradleCache('numpy-1.2.3.tar.gz')) == []
     }
 
     def "package settings build options for snapshot"() {
         expect: "empty build options"
-        packageSettings.getBuildOptions(PackageInfo.fromPath('scipy-1.2.3-SNAPSHOT.tar.gz')) == []
+        packageSettings.getBuildOptions(packageInGradleCache('scipy-1.2.3-SNAPSHOT.tar.gz')) == []
     }
 
     def "default package settings configure options"() {
         expect: "empty configure options"
-        packageSettings.getConfigureOptions(PackageInfo.fromPath('pytest-1.2.3.tar.gz')) == []
+        packageSettings.getConfigureOptions(packageInGradleCache('pytest-1.2.3.tar.gz')) == []
     }
 
     def "default package settings supported language versions"() {
         expect: "empty supported language versions"
-        packageSettings.getSupportedLanguageVersions(PackageInfo.fromPath('foo-1.2.3.tar.gz')) == []
+        packageSettings.getSupportedLanguageVersions(packageInGradleCache('foo-1.2.3.tar.gz')) == []
     }
 
     def "default package settings requires source build"() {
         expect: "does not require source build"
-        !packageSettings.requiresSourceBuild(PackageInfo.fromPath('requests-1.2.3.tar.gz'))
+        !packageSettings.requiresSourceBuild(packageInGradleCache('requests-1.2.3.tar.gz'))
     }
 
     def "package settings require source build for snapshot"() {
         expect: "snapshot requires a build"
-        packageSettings.requiresSourceBuild(PackageInfo.fromPath('requests-1.2.3-SNAPSHOT.tar.gz'))
+        packageSettings.requiresSourceBuild(packageInGradleCache('requests-1.2.3-SNAPSHOT.tar.gz'))
     }
 
     def "package settings requires a rebuild for the current project"() {
         expect: "project requires a rebuild"
-        packageSettings.requiresSourceBuild(PackageInfo.fromPath('foo-1.2.3.tar.gz'))
+        packageSettings.requiresSourceBuild(packageInGradleCache('foo-1.2.3.tar.gz'))
+    }
+
+    static PackageInfo packageInGradleCache(String name) {
+        return PackageInfo.fromPath(new File("/foo/.gradle/caches/", name))
     }
 
 }


### PR DESCRIPTION
Replace all usage of deprecated fromPath method with the new one.
Add one test that confirms that deprecated method still works until we
drop it.