### PR TITLE
Add two more items to the substitution map

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/ThinPexGenerator.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/ThinPexGenerator.java
@@ -78,6 +78,8 @@ public class ThinPexGenerator implements PexGenerator {
             propertyMap.putAll(extraProperties);
             propertyMap.put("realPex", PexFileUtil.createThinPexFilename(project.getName()));
             propertyMap.put("entryPoint", entry);
+            propertyMap.put("pythonExecutable", extension.getDetails().getSystemPythonInterpreter().getAbsolutePath());
+            propertyMap.put("toolName", project.getName());
 
             DefaultTemplateProviderOptions providerOptions = new DefaultTemplateProviderOptions(project, extension, entry);
             new EntryPointWriter(project, templateProvider.retrieveTemplate(providerOptions))


### PR DESCRIPTION
* pythonExecutable names the full path to the Python executable that the pex
  will be shebanged with.
* toolName is the project name, which can form the basis of the pex file name

Closes #207 