### PR TITLE
Fix regex to allow wheel dependencies. Fixes #210

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PackageInfo.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PackageInfo.groovy
@@ -15,6 +15,7 @@
  */
 package com.linkedin.gradle.python.util
 
+import com.linkedin.gradle.python.wheel.PythonWheelDetails
 import org.apache.commons.io.FilenameUtils
 import org.gradle.api.GradleException
 
@@ -50,6 +51,7 @@ class PackageInfo {
      *   <li>.tar</li>
      *   <li>.tgz</li>
      *   <li>.zip</li>
+     *   <li>.whl</li>
      * </ul>
      * <p>
      * A path to a expanded Python package can be provided as long as the path
@@ -65,7 +67,7 @@ class PackageInfo {
      * @param packagePath The path to a Python package.
      */
     public static PackageInfo fromPath(File packagePath) {
-        def extensionRegex = /\.tar\.gz|\.zip|\.tar|\.tar\.bz2|\.tgz/
+        def extensionRegex = /\.tar\.gz|\.zip|\.tar|\.tar\.bz2|\.tgz|\.whl/
         def nameVersionRegex = /^(?<name>[a-zA-Z0-9._\-]+)-(?<version>([0-9][0-9a-z\.]+(-.*)*))$/
 
         def filename = FilenameUtils.getName(packagePath.getPath())
@@ -77,6 +79,11 @@ class PackageInfo {
 
         if (packagePath.getName() == packageName) {
             throw new GradleException("Cannot calculate Python package extension from ${ packagePath } using regular expression /${ extensionRegex }/.")
+        }
+
+        Optional<PythonWheelDetails> pythonWheels = PythonWheelDetails.fromFile(packagePath)
+        if (pythonWheels.isPresent()) {
+            return new PackageInfo(packagePath, pythonWheels.get().getDist(), pythonWheels.get().getVersion())
         }
 
         Matcher matcher = packageName =~ nameVersionRegex

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCache.java
@@ -24,25 +24,18 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class FileBackedWheelCache implements WheelCache, Serializable {
 
     private static final Logger logger = Logging.getLogger(FileBackedWheelCache.class);
 
-    // PEP-0427
-    private static final String WHEEL_FILE_FORMAT = "(?<dist>.*?)-(?<version>.*?)(-(.*?))?-(?<pythonTag>.*?)-(?<abiTag>.*?)-(?<platformTag>.*?).whl";
-
     private final File cacheDir;
-    private final Pattern wheelPattern;
     private final SupportedWheelFormats supportedWheelFormats;
 
     public FileBackedWheelCache(File cacheDir, SupportedWheelFormats supportedWheelFormats) {
         this.cacheDir = cacheDir;
         this.supportedWheelFormats = supportedWheelFormats;
-        this.wheelPattern = Pattern.compile(WHEEL_FILE_FORMAT);
     }
 
     /**
@@ -79,7 +72,7 @@ public class FileBackedWheelCache implements WheelCache, Serializable {
             return Optional.empty();
         }
 
-        List<PythonWheelDetails> wheelDetails = Arrays.stream(files).map(this::fromFile)
+        List<PythonWheelDetails> wheelDetails = Arrays.stream(files).map(PythonWheelDetails::fromFile)
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(Collectors.toList());
@@ -105,45 +98,5 @@ public class FileBackedWheelCache implements WheelCache, Serializable {
             wheelDetails.pythonTag,
             wheelDetails.abiTag,
             wheelDetails.platformTag);
-    }
-
-    private Optional<PythonWheelDetails> fromFile(File file) {
-        Matcher matcher = wheelPattern.matcher(file.getName());
-        if (!matcher.matches()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new PythonWheelDetails(file, matcher));
-    }
-
-    private class PythonWheelDetails {
-
-        final private File file;
-        final private String dist;
-        final private String version;
-        final private String pythonTag;
-        final private String abiTag;
-        final private String platformTag;
-
-        private PythonWheelDetails(File file, Matcher matcher) {
-            this.file = file;
-            this.dist = matcher.group("dist");
-            this.version = matcher.group("version");
-            this.pythonTag = matcher.group("pythonTag");
-            this.abiTag = matcher.group("abiTag");
-            this.platformTag = matcher.group("platformTag");
-        }
-
-        @Override
-        public String toString() {
-            return "PythonWheelDetails{"
-                + "file=" + file
-                + ", dist='" + dist + '\''
-                + ", version='" + version + '\''
-                + ", pythonTag='" + pythonTag + '\''
-                + ", abiTag='" + abiTag + '\''
-                + ", platformTag='" + platformTag + '\''
-                + '}';
-        }
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/PythonWheelDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/PythonWheelDetails.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.wheel;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PythonWheelDetails {
+
+    // PEP-0427
+    public static final String WHEEL_FILE_FORMAT = "(?<dist>.*?)-(?<version>.*?)(-(.*?))?-(?<pythonTag>.*?)-(?<abiTag>.*?)-(?<platformTag>.*?).whl";
+
+    final File file;
+    final String dist;
+    final String version;
+    final String pythonTag;
+    final String abiTag;
+    final String platformTag;
+
+    public PythonWheelDetails(File file, Matcher matcher) {
+        this.file = file;
+        this.dist = matcher.group("dist");
+        this.version = matcher.group("version");
+        this.pythonTag = matcher.group("pythonTag");
+        this.abiTag = matcher.group("abiTag");
+        this.platformTag = matcher.group("platformTag");
+    }
+
+    public String getDist() {
+        return dist;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "PythonWheelDetails{"
+            + "file=" + file
+            + ", dist='" + dist + '\''
+            + ", version='" + version + '\''
+            + ", pythonTag='" + pythonTag + '\''
+            + ", abiTag='" + abiTag + '\''
+            + ", platformTag='" + platformTag + '\''
+            + '}';
+    }
+
+    static public Optional<PythonWheelDetails> fromFile(File file) {
+        Pattern wheelPattern = Pattern.compile(WHEEL_FILE_FORMAT);
+        Matcher matcher = wheelPattern.matcher(file.getName());
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new PythonWheelDetails(file, matcher));
+    }
+}

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageInfoTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageInfoTest.groovy
@@ -75,6 +75,14 @@ class PackageInfoTest extends Specification {
         thrown(GradleException)
     }
 
+    def 'can parse a wheel distribution'() {
+        when:
+        def packageInfo = packageInGradleCache('foo-1.0.0-py2-none-any.whl')
+        then:
+        assert packageInfo.name == 'foo'
+        assert packageInfo.version == '1.0.0'
+    }
+
     // TODO: Remove this test completely when we drop the deprecated method.
     def 'still supports deprecated fromPath method'() {
         when:

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/PythonWheelDetailsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/PythonWheelDetailsTest.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.wheel
+
+import spock.lang.Specification
+
+class PythonWheelDetailsTest extends Specification {
+
+    def 'can parse wheel file'() {
+        when:
+        def wheelFile = new File("foo-1.0.0-py2-none-any.whl")
+        PythonWheelDetails pythonWheelDetails = PythonWheelDetails.fromFile(wheelFile).get()
+        then:
+        pythonWheelDetails.dist == "foo"
+        pythonWheelDetails.version == "1.0.0"
+        pythonWheelDetails.pythonTag == "py2"
+        pythonWheelDetails.abiTag == "none"
+        pythonWheelDetails.platformTag == "any"
+    }
+
+    def 'can parse wheel file with SNAPSHOT version'() {
+        when:
+        def wheelFile = new File("foo-1.0.0-SNAPSHOT-py2-none-any.whl")
+        PythonWheelDetails pythonWheelDetails = PythonWheelDetails.fromFile(wheelFile).get()
+        then:
+        pythonWheelDetails.dist == "foo"
+        pythonWheelDetails.version == "1.0.0"
+        pythonWheelDetails.pythonTag == "py2"
+        pythonWheelDetails.abiTag == "none"
+        pythonWheelDetails.platformTag == "any"
+    }
+}


### PR DESCRIPTION
We used to be able to specify Python dependencies on wheels packages in the build.gradle file using the `python` configuration, but this functionality is no longer working. Issue #210 has all the details. 

Unfortunately, it seems like wheel dependencies were never officially supported, but happened to work because the regex wasn't used properly. This change fixed applying the regex, but unfortunately broke wheel dependency support as a result: https://github.com/linkedin/pygradle/commit/0a6b7b6aa96f56e82abf5db635b77c55c691e3cb#diff-f3ee7d4e9fd88d136b10b3a5262ce74fR78

Since wheel packages are a standard in the Python community and PyGradle can handle it, I would like to update the regex to allow it.

