### PR TITLE
Fix the case when projec name differs from package name.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/InstallDependenciesPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/InstallDependenciesPlugin.java
@@ -37,7 +37,6 @@ import static com.linkedin.gradle.python.util.StandardTextValues.TASK_SETUP_LINK
 public class InstallDependenciesPlugin implements Plugin<Project> {
 
     private static final String PIP_UPGRADE = "--upgrade";
-    private static final String PIP_EDITABLE = "--editable";
 
     @Override
     public void apply(final Project project) {
@@ -103,7 +102,6 @@ public class InstallDependenciesPlugin implements Plugin<Project> {
             it.setPythonDetails(settings.getDetails());
             it.dependsOn(project.getTasks().getByName(TASK_INSTALL_PYTHON_REQS.getValue()));
             it.setInstallFileCollection(project.files(project.file(project.getProjectDir())));
-            it.setArgs(Collections.singletonList(PIP_EDITABLE));
             it.setEnvironment(settings.pythonEnvironmentDistgradle);
         });
     }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageSettingsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageSettingsTest.groovy
@@ -46,8 +46,9 @@ class PackageSettingsTest extends Specification {
     }
 
     def "package settings install options for project snapshot()"() {
-        expect: "project snapshot does not use --ignore-installed because it's installed editable"
-        packageSettings.getInstallOptions(packageInGradleCache('foo-1.2.3-SNAPSHOT.tar.gz')) == []
+        expect: "project snapshot uses --ignore-installed and --editable"
+        packageSettings.getInstallOptions(packageInGradleCache('foo-1.2.3-SNAPSHOT.tar.gz')) == [
+            '--ignore-installed', '--editable']
     }
 
     def "default package settings build options"() {


### PR DESCRIPTION
The Python package name can be different from the Gradle project name.
In that case the `--ignore-installed` option was passed after
`--editable` option that expects a directory name, and failed.

Instead of passing `--editable` separately, we'll use the
packageSettings framework and pass it always last after not only
`--ignore-installed`, but also after any other potential
`--install-option ...` options. Thus, another potential bug is fixed
because `--editable` will always be right before the package directory
name.