### PR TITLE
Fix the regex for wheel file name format.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCache.java
@@ -85,7 +85,7 @@ public class FileBackedWheelCache implements WheelCache, Serializable {
 
         logger.info("Found artifacts: {}", foundWheel);
 
-        return foundWheel.map(it -> it.file);
+        return foundWheel.map(it -> it.getFile());
     }
 
     public File getCacheDir() {
@@ -95,8 +95,8 @@ public class FileBackedWheelCache implements WheelCache, Serializable {
     private boolean wheelMatches(File pythonExecutable, PythonWheelDetails wheelDetails) {
         return supportedWheelFormats.matchesSupportedVersion(
             pythonExecutable,
-            wheelDetails.pythonTag,
-            wheelDetails.abiTag,
-            wheelDetails.platformTag);
+            wheelDetails.getPythonTag(),
+            wheelDetails.getAbiTag(),
+            wheelDetails.getPlatformTag());
     }
 }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/PythonWheelDetailsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/PythonWheelDetailsTest.groovy
@@ -33,11 +33,11 @@ class PythonWheelDetailsTest extends Specification {
 
     def 'can parse wheel file with SNAPSHOT version'() {
         when:
-        def wheelFile = new File("foo-1.0.0-SNAPSHOT-py2-none-any.whl")
+        def wheelFile = new File("foo-1.0.0_SNAPSHOT-py2-none-any.whl")
         PythonWheelDetails pythonWheelDetails = PythonWheelDetails.fromFile(wheelFile).get()
         then:
         pythonWheelDetails.dist == "foo"
-        pythonWheelDetails.version == "1.0.0"
+        pythonWheelDetails.version == "1.0.0-SNAPSHOT"
         pythonWheelDetails.pythonTag == "py2"
         pythonWheelDetails.abiTag == "none"
         pythonWheelDetails.platformTag == "any"


### PR DESCRIPTION
This fixes the regex to disallow empty parts.
It also takes care of converting correctly "_SNAPSHOT" back into
"-SNAPSHOT" (or similar semver.org pre-release formats).