### PR TITLE
Fix handling of project name and directory.

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PackageSettingsIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PackageSettingsIntegrationTest.groovy
@@ -44,7 +44,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     Map<String, String> getEnvironment(PackageInfo packageInfo) {
@@ -58,7 +58,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.PipInstallTask
         |
         | project.tasks.withType(PipInstallTask) { PipInstallTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -100,7 +100,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     List<String> getGlobalOptions(PackageInfo packageInfo) {
@@ -111,7 +111,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.PipInstallTask
         |
         | project.tasks.withType(PipInstallTask) { PipInstallTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -152,7 +152,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     List<String> getInstallOptions(PackageInfo packageInfo) {
@@ -163,7 +163,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.PipInstallTask
         |
         | project.tasks.withType(PipInstallTask) { PipInstallTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -204,7 +204,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     List<String> getSupportedLanguageVersions(PackageInfo packageInfo) {
@@ -215,7 +215,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.PipInstallTask
         |
         | project.tasks.withType(PipInstallTask) { PipInstallTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -262,7 +262,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     boolean requiresSourceBuild(PackageInfo packageInfo) {
@@ -273,7 +273,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.PipInstallTask
         |
         | project.tasks.withType(PipInstallTask) { PipInstallTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -317,7 +317,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     Map<String, String> getEnvironment(PackageInfo packageInfo) {
@@ -331,7 +331,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.BuildWheelsTask
         |
         | project.tasks.withType(BuildWheelsTask) { BuildWheelsTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -374,7 +374,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     List<String> getGlobalOptions(PackageInfo packageInfo) {
@@ -385,7 +385,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.BuildWheelsTask
         |
         | project.tasks.withType(BuildWheelsTask) { BuildWheelsTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -435,7 +435,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     List<String> getBuildOptions(PackageInfo packageInfo) {
@@ -446,7 +446,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.BuildWheelsTask
         |
         | project.tasks.withType(BuildWheelsTask) { BuildWheelsTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -496,7 +496,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     List<String> getSupportedLanguageVersions(PackageInfo packageInfo) {
@@ -507,7 +507,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.BuildWheelsTask
         |
         | project.tasks.withType(BuildWheelsTask) { BuildWheelsTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}
@@ -554,7 +554,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.util.PackageInfo
         |
         | class DefaultTestPackageSettings extends DefaultPackageSettings {
-        |     DefaultTestPackageSettings(String projectName) { super(projectName) }
+        |     DefaultTestPackageSettings(File projectDir) { super(projectDir) }
         |
         |     @Override
         |     boolean requiresSourceBuild(PackageInfo packageInfo) {
@@ -565,7 +565,7 @@ class PackageSettingsIntegrationTest extends Specification {
         | import com.linkedin.gradle.python.tasks.BuildWheelsTask
         |
         | project.tasks.withType(BuildWheelsTask) { BuildWheelsTask task ->
-        |     task.packageSettings = new DefaultTestPackageSettings(project.name)
+        |     task.packageSettings = new DefaultTestPackageSettings(project.projectDir)
         | }
         |
         |${PyGradleTestBuilder.createRepoClosure()}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.java
@@ -60,7 +60,7 @@ public class PythonPlugin implements Plugin<Project> {
         createConfigurations(project);
         configureVendedDependencies(project, settings);
 
-        DefaultPackageSettings packageSettings = new DefaultPackageSettings(project.getName());
+        DefaultPackageSettings packageSettings = new DefaultPackageSettings(project.getProjectDir());
         project.getTasks().withType(SupportsPackageInfoSettings.class, it -> it.setPackageSettings(packageSettings));
 
         /*

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageSettingsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/PackageSettingsTest.groovy
@@ -15,6 +15,7 @@
  */
 package com.linkedin.gradle.python.util
 
+import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 
@@ -22,7 +23,9 @@ import spock.lang.Specification
  * Unit tests for package settings implementers.
  */
 class PackageSettingsTest extends Specification {
-    PackageSettings<PackageInfo> packageSettings = new DefaultPackageSettings('foo')
+    def project = new ProjectBuilder().build()
+    def projectPath = project.file(project.getProjectDir())
+    PackageSettings<PackageInfo> packageSettings = new DefaultPackageSettings(project.projectDir)
 
     def "default package settings environment"() {
         expect: "empty environment"
@@ -47,8 +50,7 @@ class PackageSettingsTest extends Specification {
 
     def "package settings install options for project snapshot()"() {
         expect: "project snapshot uses --ignore-installed and --editable"
-        packageSettings.getInstallOptions(packageInGradleCache('foo-1.2.3-SNAPSHOT.tar.gz')) == [
-            '--ignore-installed', '--editable']
+        packageSettings.getInstallOptions(PackageInfo.fromPath(projectPath)) == ['--ignore-installed', '--editable']
     }
 
     def "default package settings build options"() {
@@ -68,7 +70,7 @@ class PackageSettingsTest extends Specification {
 
     def "default package settings supported language versions"() {
         expect: "empty supported language versions"
-        packageSettings.getSupportedLanguageVersions(packageInGradleCache('foo-1.2.3.tar.gz')) == []
+        packageSettings.getSupportedLanguageVersions(PackageInfo.fromPath(projectPath)) == []
     }
 
     def "default package settings requires source build"() {
@@ -83,7 +85,7 @@ class PackageSettingsTest extends Specification {
 
     def "package settings requires a rebuild for the current project"() {
         expect: "project requires a rebuild"
-        packageSettings.requiresSourceBuild(packageInGradleCache('foo-1.2.3.tar.gz'))
+        packageSettings.requiresSourceBuild(PackageInfo.fromPath(projectPath))
     }
 
     static PackageInfo packageInGradleCache(String name) {


### PR DESCRIPTION
If a meta-package matches a dependency package name, it may get
`--editable` during the install of the dependency and fail.

This change ensures that we're processing the project directory by
confirming that all of the following are true: version is not set,
package file is a directory, package directory matches the project
directory.  The last check is for packages that have projects named
containing-dir/backend and package name ends up being just backend.

The order of checks is intentional to cut checks as early as possible.
Hence the version check first, since other packages will have it set.