### PR TITLE
Upgrade pip to 9.0.3.

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -52,7 +52,7 @@ task importRequiredDependencies(type: JavaExec) { task ->
         'Flask:0.12.2',
         'pbr:1.8.0',
         'pex:1.2.13',
-        'pip:9.0.1',
+        'pip:9.0.3',
         'pytest:3.1.2',
         'pytest-cov:2.5.1',
         'pytest-xdist:1.17.1',
@@ -67,6 +67,7 @@ task importRequiredDependencies(type: JavaExec) { task ->
     def forceDeps = [
         'setuptools:33.1.1',
         'wheel:0.29.0',
+        'pip:9.0.3',
     ].join(',')
     args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements --force $forceDeps".split(' ')
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -66,7 +66,7 @@ class PythonExtension {
         'argparse'      : ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '2.6.2'],
         'pex'           : ['group': 'pypi', 'name': 'pex', 'version': '1.2.13'],
-        'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '9.0.1'],
+        'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '9.0.3'],
         'pytest'        : ['group': 'pypi', 'name': 'pytest', 'version': '3.1.2'],
         'pytest-cov'    : ['group': 'pypi', 'name': 'pytest-cov', 'version': '2.5.1'],
         'pytest-xdist'  : ['group': 'pypi', 'name': 'pytest-xdist', 'version': '1.17.1'],

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -159,10 +159,6 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
             def clock = taskTimer.start(shortHand)
             progressLogger.progress("Preparing wheel $shortHand (${ ++counter } of $numberOfInstallables)")
 
-            if (PythonHelpers.isPlainOrVerbose(project)) {
-                LOGGER.lifecycle("Installing {} wheel", shortHand)
-            }
-
             if (packageExcludeFilter != null && packageExcludeFilter.isSatisfiedBy(packageInfo)) {
                 if (PythonHelpers.isPlainOrVerbose(project)) {
                     LOGGER.lifecycle("Skipping {} wheel - Excluded", shortHand)
@@ -198,8 +194,13 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
                     include: "**/${ packageInfo.name.replace('-', '_') }-${ (packageInfo.version ?: 'unspecified').replace('-', '_') }-*.whl")
 
                 if (tree.files.size() >= 1) {
+                    LOGGER.lifecycle("Skipping {} wheel - Installed", shortHand)
                     return
                 }
+            }
+
+            if (PythonHelpers.isPlainOrVerbose(project)) {
+                LOGGER.lifecycle("Installing {} wheel", shortHand)
             }
 
             def stream = new ByteArrayOutputStream()


### PR DESCRIPTION
This version of pip vends the pkg_resources that match better with
setuptools>31.x.

Also, reorder logging in build wheels task to match the pip install task
and produce only one line for package: either excluded, skipped, or
installing, rather than multiple lines and ambiguous messages.