### PR TITLE
Update PyPI URL.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,7 +19,6 @@ This project uses the following in the plugin:
 This project uses the following part of the python environment:
     argparse (https://github.com/ThomasWaldmann/argparse/) - Python Software Foundation License
     flake8 (https://gitlab.com/pycqa/flake8) - MIT
-    pbr (https://launchpad.net/pbr) - Apache License 2.0
     pex (https://github.com/pantsbuild/pex) - Apache License 2.0
     pip (https://pip.pypa.io/) - MIT
     pytest (http://pytest.org) - MIT
@@ -27,8 +26,7 @@ This project uses the following part of the python environment:
     pytest-xdist (https://github.com/pytest-dev/pytest-xdist) - MIT
     setuptools (https://github.com/pypa/setuptools) - MIT
     setuptools-git (https://github.com/wichert/setuptools-git) - BSD
-    six (http://pypi.python.org/pypi/six/) - MIT
+    six (http://pypi.org/pypi/six/) - MIT
     Sphinx (http://sphinx-doc.org/) - BSD
-    unittest2 (http://pypi.python.org/pypi/unittest2) - BSD
     virtualenv (https://virtualenv.pypa.io/) - MIT
-    wheel (https://bitbucket.org/pypa/wheel/) - MIT
+    wheel (https://github.com/pypa/wheel/) - MIT

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ Guide](https://docs.gradle.org/3.3/userguide/userguide.html).
 ## Hosting
 
 The Python community maintains [The Python Package
-Index](https://pypi.python.org/pypi), or PyPI for short, to host open source
+Index](https://pypi.org), or PyPI for short, to host open source
 Python artifacts.
 
 Unfortunately, PyGradle cannot leverage PyPI yet for one primary reason: open

--- a/docs/plugins/python.md
+++ b/docs/plugins/python.md
@@ -33,7 +33,7 @@ plugins {
 
 ## pipConfig Examples
 Sometimes you need to configure pip inside of the venv itself.  The most common use cases are when you don't use 
-pypi.python.com, but you use your own internal pypi server, or you need to set a proxy.  Typically, you can configure 
+pypi.org, but you use your own internal pypi server, or you need to set a proxy.  Typically, you can configure
 this with an operating system
 level pip.* file as documented on the [pip web site](https://pip.pypa.io/en/stable/user_guide/#config-file).  But
 occasionally you need to configure this on a per-project basis.  This is where this setting comes in.  Take this example

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/PypiApiCache.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/PypiApiCache.groovy
@@ -31,7 +31,7 @@ class PypiApiCache {
     }
 
     static private Map<String, Object> downloadMetadata(String dependency) {
-        def url = "https://pypi.python.org/pypi/$dependency/json"
+        def url = "https://pypi.org/pypi/$dependency/json"
         log.debug("Metadata url: {}", url)
         def proxy = ProxyDetector.maybeGetHttpProxy()
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pip/PipConfFile.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pip/PipConfFile.java
@@ -48,7 +48,7 @@ public class PipConfFile {
      * Writes a new pip.conf file.  You can configure the contents of this file with the python extension
      * or leave it blank for it to pick up the pip.conf in your system properties.
      * <p>
-     * index-url = https://pypi.python.org/simple/
+     * index-url = https://pypi.org/simple/
      */
     public void buildPipConfFile() throws IOException {
 


### PR DESCRIPTION
PyPI moved to pypi.org instead of pypi.python.org.
Fixed couple of other references too.