### PR TITLE
Fix the permission for CheckStyleXmlReporter.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/checkstyle/CheckStyleXmlReporter.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/checkstyle/CheckStyleXmlReporter.java
@@ -27,11 +27,11 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.StringWriter;
 
-class CheckStyleXmlReporter {
+public class CheckStyleXmlReporter {
 
     private final FileStyleViolationsContainer violationContainer;
 
-    CheckStyleXmlReporter(FileStyleViolationsContainer container) {
+    public CheckStyleXmlReporter(FileStyleViolationsContainer container) {
         this.violationContainer = container;
     }
 


### PR DESCRIPTION
During refactoring this class was migrated from Groovy to Java in #176,
but the permissions on it changed. It was implicitly public in Groovy
and it was not made explicitly public in Java. Instead it was package
scoped and thus inaccessible from the task that was using it.