### PR TITLE
ParallelWheels needed SetupRequires before building wheels

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/testutils/ExecUtils.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/testutils/ExecUtils.groovy
@@ -26,6 +26,10 @@ import java.nio.file.Path
 class ExecUtils {
 
     static String run(Path path) {
+        return run(path, new String[0])
+    }
+
+    static String run(Path path, String... args) {
 
         ByteArrayOutputStream os = new ByteArrayOutputStream()
         def executor = new DefaultExecutor()
@@ -34,6 +38,7 @@ class ExecUtils {
         def cmd = OperatingSystem.current().isWindows() ? "python ${path.toString()}" : path.toString()
 
         def commandLine = CommandLine.parse(cmd)
+        commandLine.addArguments(args)
 
         try {
             executor.execute(commandLine)

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/WheelFirstPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/WheelFirstPlugin.java
@@ -17,10 +17,10 @@ package com.linkedin.gradle.python.plugin;
 
 import com.linkedin.gradle.python.tasks.FindAbiForCurrentPythonTask;
 import com.linkedin.gradle.python.tasks.ParallelWheelGenerationTask;
+import com.linkedin.gradle.python.tasks.supports.SupportsWheelCache;
 import com.linkedin.gradle.python.util.ExtensionUtils;
 import com.linkedin.gradle.python.wheel.FileBackedWheelCache;
 import com.linkedin.gradle.python.wheel.SupportedWheelFormats;
-import com.linkedin.gradle.python.tasks.supports.SupportsWheelCache;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
@@ -37,6 +37,7 @@ import static com.linkedin.gradle.python.util.StandardTextValues.CONFIGURATION_S
 import static com.linkedin.gradle.python.util.StandardTextValues.CONFIGURATION_TEST;
 import static com.linkedin.gradle.python.util.StandardTextValues.CONFIGURATION_VENV;
 import static com.linkedin.gradle.python.util.StandardTextValues.CONFIGURATION_WHEEL;
+import static com.linkedin.gradle.python.util.StandardTextValues.TASK_INSTALL_SETUP_REQS;
 import static com.linkedin.gradle.python.util.StandardTextValues.TASK_VENV_CREATE;
 
 public class WheelFirstPlugin implements Plugin<Project> {
@@ -72,12 +73,14 @@ public class WheelFirstPlugin implements Plugin<Project> {
                 it.setWheelCache(wheelCache);
                 it.setCacheDir(cacheDir);
                 it.dependsOn(tasks.getByName(TASK_VENV_CREATE.getValue()));
+                it.dependsOn(tasks.getByName(TASK_INSTALL_SETUP_REQS.getValue()));
             });
 
             tasks.withType(SupportsWheelCache.class, it -> {
                 it.setWheelCache(wheelCache);
 
-                if (!Objects.equals(it.getName(), TASK_VENV_CREATE.getValue())) {
+                if (!Objects.equals(it.getName(), TASK_VENV_CREATE.getValue())
+                    && !Objects.equals(it.getName(), TASK_INSTALL_SETUP_REQS.getValue())) {
                     it.dependsOn(parallelWheelTask);
                 }
             });


### PR DESCRIPTION
There was an issue where the ParallelWheels task wouldn't have the
setupRequires dependencies installed until after the wheel was
generated. This causes issues with namespace pacakges and can lead to
indeterminate import errors.

Also, we should not build wheels and put them into the global cache
with extra dependencies other than the setup-requires deps. So we check
to see that there are only the dependenices we care about in the venv.