### PR TITLE
Fix env regex in integ test.

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PackageSettingsIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PackageSettingsIntegrationTest.groovy
@@ -51,6 +51,7 @@ class PackageSettingsIntegrationTest extends Specification {
         |         return (packageInfo.name != 'foo') ? [:] : [
         |             'CPPFLAGS': '-I/some/custom/path/include',
         |             'LDFLAGS': '-L/some/custom/path/lib -Wl,-rpath,/some/custom/path/lib',
+        |             'DUMMY_MAP': '{\\n}',
         |         ]
         |     }
         | }
@@ -74,7 +75,7 @@ class PackageSettingsIntegrationTest extends Specification {
         println result.output
 
         then: "we can observe the environment for 'foo' provided a few lines after its install is logged"
-        def match = result.output.find(/Installing foo[\s\S]+?Environment for[^\n]+: \{.+\}\s*\n/)
+        def match = result.output.find(/Installing foo[\s\S]+?Environment for[^\n]+: \{[\s\S]+?\}\s*\n/)
         match != null
         match.findAll('Installing ').size() == 1
         match.contains('CPPFLAGS=-I/some/custom/path/include')
@@ -324,6 +325,7 @@ class PackageSettingsIntegrationTest extends Specification {
         |         return (packageInfo.name != 'foo') ? [:] : [
         |             'CPPFLAGS': '-I/some/custom/path/include',
         |             'LDFLAGS': '-L/some/custom/path/lib -Wl,-rpath,/some/custom/path/lib',
+        |             'DUMMY_MAP': '{\\n}',
         |         ]
         |     }
         | }
@@ -347,7 +349,7 @@ class PackageSettingsIntegrationTest extends Specification {
         println result.output
 
         then: "we can observe the environment for 'foo' provided a few lines after its build is logged"
-        def match = result.output.find(/Installing foo\S* wheel[\s\S]+?Environment for[^\n]+: \{.+\}\s*\n/)
+        def match = result.output.find(/Installing foo\S* wheel[\s\S]+?Environment for[^\n]+: \{[\s\S]+?\}\s*\n/)
         match != null
         match.findAll('Installing ').size() == 1
         match.contains('CPPFLAGS=-I/some/custom/path/include')


### PR DESCRIPTION
This is a take two.
Account for newlines in environment that Travis inserts sometimes.
Add a variable to environment in the tests that has both braces and
newlines to cover Travis and Circle CI specific environments.