### PR TITLE
Update mock dependency version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,7 +122,7 @@ Finally, lets write some Gradle code.
 
     dependencies {
         python 'pypi:requests:2.9.1'
-        test 'pypi:mock:1.0.1'
+        test 'pypi:mock:2.0.0'
     }
 
     repositories {


### PR DESCRIPTION
LinkedIn's [public Artifactory](https://linkedin.jfrog.io/linkedin/webapp/#/artifacts/browse/tree/General/pypi-external/pypi/mock) no longer contains the `1.0.1` version of this mock dependency. This upgrades it so the getting started can keep flowing smoothly