### PR TITLE
Upgrade to pex-1.4.6.

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -54,23 +54,23 @@ task importRequiredDependencies(type: JavaExec) { task ->
         'flake8:2.6.2',
         'Flask:0.12.2',
         'pbr:1.8.0',
-        'pex:1.2.13',
-        'pip:9.0.3',
+        'pex:1.4.6',
+        'pip:18.0',
         'pytest:3.1.2',
         'pytest-cov:2.5.1',
         'pytest-xdist:1.17.1',
         'requests:2.18.1',
-        'setuptools:33.1.1',
+        'setuptools:40.4.1',
         'setuptools-git:1.2',
         'six:1.11.0',
         'Sphinx:1.4.9',
-        'virtualenv:15.1.0',
-        'wheel:0.29.0',
+        'virtualenv:16.0.0',
+        'wheel:0.31.1',
     ].join(" ")
     def forceDeps = [
-        'setuptools:33.1.1',
-        'wheel:0.29.0',
-        'pip:9.0.3',
+        'setuptools:40.4.1',
+        'wheel:0.31.1',
+        'pip:18.0',
     ].join(',')
     args "--repo ${getIvyRepo().absolutePath} $packagesToInclude --replace $replacements --force $forceDeps".split(' ')
 

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/ParallelWheelsIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/ParallelWheelsIntegrationTest.groovy
@@ -135,9 +135,9 @@ class ParallelWheelsIntegrationTest extends Specification {
         def output = ExecUtils.run(venvPath.resolve("bin/pip"), "freeze", "--all")
         println(output)
         // Note: These versions will change over time
-        output.contains("wheel==0.29.0")
-        output.contains("pip==9.0.3")
-        output.contains("setuptools==33.1.1")
+        output.contains("wheel==0.31.1")
+        output.contains("pip==18.0")
+        output.contains("setuptools==40.4.1")
         result.task(':foo:findPythonAbi') == null //task was removed and is no longer needed
         result.task(':foo:parallelWheels').outcome == TaskOutcome.SUCCESS
 

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PexIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PexIntegrationTest.groovy
@@ -62,9 +62,9 @@ class PexIntegrationTest extends Specification {
 
         Path deployablePath = testProjectDir.root.toPath().resolve(Paths.get('foo', 'build', 'deployable', "bin"))
 
-        then: "it succeeds and the hyphen was converted into underscore for pex command due to pex bug workaround"
+        then: "it succeeds and the hyphen was NOT converted into underscore for snapshot as it did with old pex bug"
 
-        result.output.find("pex [^\n]+ foo==1.0.0_SNAPSHOT")
+        result.output.find("pex [^\n]+ foo==1.0.0-SNAPSHOT")
         result.output.contains("BUILD SUCCESS")
         result.task(':foo:flake8').outcome == TaskOutcome.SUCCESS
         result.task(':foo:installPythonRequirements').outcome == TaskOutcome.SUCCESS

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PyGradleWithSlimProjectsTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PyGradleWithSlimProjectsTest.groovy
@@ -43,7 +43,7 @@ class PyGradleWithSlimProjectsTest extends Specification {
         |     id 'com.linkedin.python'
         | }
         | python{
-        |     pipConfig = ['global':['index-url': 'https://<login>:<password>@your.repo.com/custom/url', 'timeout': '60']]
+        |     pipConfig = ['global':['extra-index-url': 'https://<login>:<password>@your.repo.com/custom/url', 'timeout': '60']]
         | }
         |
         | ${PyGradleTestBuilder.createRepoClosure()}
@@ -77,7 +77,7 @@ class PyGradleWithSlimProjectsTest extends Specification {
         fpip.exists()
         def lines = fpip.readLines()
         lines.get(0) == "[global]"
-        lines.get(1) == "index-url = https://<login>:<password>@your.repo.com/custom/url"
+        lines.get(1) == "extra-index-url = https://<login>:<password>@your.repo.com/custom/url"
         lines.get(2) == "timeout = 60"
 
         // "Build will skip things that it should"
@@ -111,7 +111,7 @@ class PyGradleWithSlimProjectsTest extends Specification {
         |     id 'com.linkedin.python'
         | }
         | python{
-        |     pipConfig = ['global':['index-url': 'https://<login>:<password>@your.repo.com/custom/url', 'timeout': '60']]
+        |     pipConfig = ['global':['extra-index-url': 'https://<login>:<password>@your.repo.com/custom/url', 'timeout': '60']]
         | }
         | ${PyGradleTestBuilder.createRepoClosure()}
         """.stripMargin().stripIndent()

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -65,17 +65,17 @@ class PythonExtension {
     public Map<String, Map<String, String>> forcedVersions = [
         'argparse'      : ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '2.6.2'],
-        'pex'           : ['group': 'pypi', 'name': 'pex', 'version': '1.2.13'],
-        'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '9.0.3'],
+        'pex'           : ['group': 'pypi', 'name': 'pex', 'version': '1.4.6'],
+        'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '18.0'],
         'pytest'        : ['group': 'pypi', 'name': 'pytest', 'version': '3.1.2'],
         'pytest-cov'    : ['group': 'pypi', 'name': 'pytest-cov', 'version': '2.5.1'],
         'pytest-xdist'  : ['group': 'pypi', 'name': 'pytest-xdist', 'version': '1.17.1'],
-        'setuptools'    : ['group': 'pypi', 'name': 'setuptools', 'version': '33.1.1'],
+        'setuptools'    : ['group': 'pypi', 'name': 'setuptools', 'version': '40.4.1'],
         'setuptools-git': ['group': 'pypi', 'name': 'setuptools-git', 'version': '1.2'],
         'six'           : ['group': 'pypi', 'name': 'six', 'version': '1.11.0'],
         'Sphinx'        : ['group': 'pypi', 'name': 'Sphinx', 'version': '1.4.9'],
-        'virtualenv'    : ['group': 'pypi', 'name': 'virtualenv', 'version': '15.1.0'],
-        'wheel'         : ['group': 'pypi', 'name': 'wheel', 'version': '0.29.0'],
+        'virtualenv'    : ['group': 'pypi', 'name': 'virtualenv', 'version': '16.0.0'],
+        'wheel'         : ['group': 'pypi', 'name': 'wheel', 'version': '0.31.1'],
     ]
 
     /* Container of the details related to the venv/python instance */

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecSpecAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/internal/pex/PexExecSpecAction.java
@@ -155,17 +155,21 @@ class PexExecSpecAction implements Action<ExecSpec> {
         List<String> requirements = new ArrayList<>();
         for (Map.Entry<String, String> entry : dependencies.entrySet()) {
             /*
-             * Work around the bug in pex.
-             * It does not follow PEP 427 completely: https://www.python.org/dev/peps/pep-0427/
-             * It turns hyphens into underscored for wheel file name in package (distribution) name only,
-             * but it does not do the same for package version.
-             * The pep is quite clear about this:
+             * NOTE: There used to be a workaround for the bug in pex here.
+             * It did not follow PEP 427 completely: https://www.python.org/dev/peps/pep-0427/
+             * It turned hyphens into underscores for wheel file name in package (distribution) name only,
+             * but it did not do the same for package version.
+             * The PEP is quite clear about this:
              *     "Each component of the filename is escaped by replacing runs of non-alphanumeric characters
              *     with an underscore _"
-             * On the other hand, pip handles this correctly, so there's a discrepancy.
-             * Until pex fixes this bug, we have to tell it that version in the file name has underscore.
+             * On the other hand, pip handles this correctly, so there was a discrepancy.
+             * Until pex fixed this bug, we had to tell it that version in the file name has underscore.
+             *
+             * Leaving this comment here in case there's a regression again.
+             * It seems that pex has fixed this between 1.2.13 and 1.4.5.
+             * We used to need `.replace("-", "_"));` instead of `);` at the end below.
              */
-            requirements.add(entry.getKey() + "==" + entry.getValue().replace("-", "_"));
+            requirements.add(entry.getKey() + "==" + entry.getValue());
         }
         return requirements;
     }


### PR DESCRIPTION
This finally allows us to move to newer setuptools and wheel that are
able to parse the new syntax for conditional dependencies in
install_requires instead of extras_require in setup of Python packages.
Using the opportunity to upgrade virtualenv, so that its vended versions
of setuptools, wheel, and pip better match the new ones. Finally,
upgrading to the latest pip too.