### PR TITLE
Verify that we can pass shortcuts to pythonVersion

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
@@ -142,7 +142,8 @@ public class DefaultPythonDetails implements PythonDetails, Serializable {
     public void setPythonVersion(String version) {
         setPythonVersionNumber(version);
         OperatingSystem operatingSystem = OperatingSystem.current();
-        pythonInterpreter = operatingSystem.findInPath(searchPath, operatingSystem.getExecutableName(String.format("python%s", version)));
+        pythonInterpreter = operatingSystem.findInPath(searchPath,
+                                                       operatingSystem.getExecutableName(String.format("python%s", pythonVersion)));
         updateFromPythonInterpreter();
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
@@ -140,10 +140,11 @@ public class DefaultPythonDetails implements PythonDetails, Serializable {
 
     @Override
     public void setPythonVersion(String version) {
-        setPythonVersionNumber(version);
+        String normalizedVersion = setPythonVersionNumber(version);
         OperatingSystem operatingSystem = OperatingSystem.current();
-        pythonInterpreter = operatingSystem.findInPath(searchPath,
-                                                       operatingSystem.getExecutableName(String.format("python%s", pythonVersion)));
+        pythonInterpreter = operatingSystem.findInPath(
+            searchPath,
+            operatingSystem.getExecutableName(String.format("python%s", normalizedVersion)));
         updateFromPythonInterpreter();
     }
 
@@ -151,8 +152,8 @@ public class DefaultPythonDetails implements PythonDetails, Serializable {
        the file system for a Python interpreter.  See
        DefaultPythonDetailsTest.groovy
     */
-    public void setPythonVersionNumber(String version) {
-        pythonVersion = pythonDefaultVersions.normalize(version);
+    public String setPythonVersionNumber(String version) {
+        return pythonDefaultVersions.normalize(version);
     }
 
     public void setPythonInterpreter(PythonVersion pythonVersion, File pythonInterpreter) {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
@@ -140,10 +140,18 @@ public class DefaultPythonDetails implements PythonDetails, Serializable {
 
     @Override
     public void setPythonVersion(String version) {
-        version = pythonDefaultVersions.normalize(version);
+        setPythonVersionNumber(version);
         OperatingSystem operatingSystem = OperatingSystem.current();
         pythonInterpreter = operatingSystem.findInPath(searchPath, operatingSystem.getExecutableName(String.format("python%s", version)));
         updateFromPythonInterpreter();
+    }
+
+    /* This is primarily used for the test suite because it avoids searching
+       the file system for a Python interpreter.  See
+       DefaultPythonDetailsTest.groovy
+    */
+    public void setPythonVersionNumber(String version) {
+        version = pythonDefaultVersions.normalize(version);
     }
 
     public void setPythonInterpreter(PythonVersion pythonVersion, File pythonInterpreter) {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/internal/DefaultPythonDetails.java
@@ -152,7 +152,7 @@ public class DefaultPythonDetails implements PythonDetails, Serializable {
        DefaultPythonDetailsTest.groovy
     */
     public void setPythonVersionNumber(String version) {
-        version = pythonDefaultVersions.normalize(version);
+        pythonVersion = pythonDefaultVersions.normalize(version);
     }
 
     public void setPythonInterpreter(PythonVersion pythonVersion, File pythonInterpreter) {

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/DefaultPythonDetailsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/DefaultPythonDetailsTest.groovy
@@ -38,11 +38,35 @@ class DefaultPythonDetailsTest extends Specification {
        It does seem like this one can be tested though.
      */
     def 'test set to unacceptable version'() {
+        given:
+        details.pythonDefaultVersions = new PythonDefaultVersions(['2.7', '3.5', '3.6'])
+
         when:
-        details.setPythonDefaultVersions(new PythonDefaultVersions(['2.7', '3.5', '3.6']))
-        details.setPythonVersion('2.5')
+        details.pythonVersion = '2.5'
 
         then:
         thrown(GradleException)
+    }
+
+    def 'test set to just Python 2'() {
+        given:
+        details.setPythonInterpreter(new PythonVersion("2.7"), new File("/foo/bar/venv/python"))
+
+        when:
+        details.pythonVersionNumber = '2'
+
+        then:
+        details.pythonVersion.toString() == "PythonVersion{version='2.7'}"
+    }
+
+    def 'test set to just Python 3'() {
+        given:
+        details.setPythonInterpreter(new PythonVersion("3.7"), new File("/foo/bar/venv/python"))
+
+        when:
+        details.pythonVersionNumber = '3'
+
+        then:
+        details.pythonVersion.toString() == "PythonVersion{version='3.7'}"
     }
 }


### PR DESCRIPTION
Add some tests that verify that we can pass "2" and "3" as shortcuts for the default Python versions.