### PR TITLE
Replace old version of rtd theme.

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -49,6 +49,7 @@ task importRequiredDependencies(type: JavaExec) { task ->
         'setuptools:0.6a2=setuptools:19.1.1',               // candidate for removal
         'setuptools:0.6c1=setuptools:19.1.1',
         'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1',      // candidate for removal
+        'sphinx_rtd_theme:0.1.0=sphinx_rtd_theme:0.1.1',      // candidate for removal
     ].join(",")
     def packagesToInclude = [
         'flake8:2.6.2',


### PR DESCRIPTION
For some reason, it's now referred to as 0.1.0.
We already had a replacement for 0.1.
Adding this other version spelling to replacements fixes the issue.