### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,7 +17,6 @@ This project uses the following in the plugin:
     Gradle (http://gradle.org) - Apache License 2.0
 
 This project uses the following part of the python environment:
-    argparse (https://github.com/ThomasWaldmann/argparse/) - Python Software Foundation License
     flake8 (https://gitlab.com/pycqa/flake8) - MIT
     pex (https://github.com/pantsbuild/pex) - Apache License 2.0
     pip (https://pip.pypa.io/) - MIT

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,11 +2,11 @@
 
 ## Linux
 
-There aren't any known compatability issues on Linux.
+There aren't any known compatibility issues on Linux.
 
 ## OS X
 
-There aren't any known compatability issues on OS X.
+There aren't any known compatibility issues on OS X.
 
 ## Windows
 
@@ -15,6 +15,10 @@ offically supported on Windows, while it seems to work properly we cannot
 guarantee it.
 
 We're eager to review pull requests from our Windows user base!
+
+## Python
+
+pygradle currently supports Python 2.7, and 3.4 - 3.7.
 
 ### Caveats
 

--- a/docs/pivy-importer.md
+++ b/docs/pivy-importer.md
@@ -101,7 +101,6 @@ sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1
 08:44:24.514 INFO  c.l.p.i.deps.DependencyDownloader - Pulling in mock:2.0.0
 08:44:24.803 INFO  c.l.p.i.deps.DependencyDownloader - Pulling in py:1.4.29
 08:44:24.821 INFO  c.l.p.i.deps.DependencyDownloader - Pulling in colorama:0.3.7
-08:44:24.832 INFO  c.l.p.i.deps.DependencyDownloader - Pulling in argparse:1.4.0
 08:44:24.844 INFO  c.l.p.i.deps.DependencyDownloader - Pulling in pbr:0.11.0
 08:44:24.858 INFO  c.l.p.i.deps.DependencyDownloader - Pulling in six:1.9.0
 08:44:24.867 INFO  c.l.p.i.deps.DependencyDownloader - Pulling in funcsigs:1.0.0

--- a/docs/plugins/python.md
+++ b/docs/plugins/python.md
@@ -17,7 +17,7 @@ The `com.linkedin.python` plugin adds an extension called `python` to the projec
     details {
         virtualEnvPrompt = "(${project.name})"
         activateLink = project.file("activate") // File you can source to activate the virtual env
-        // pythonVersion = '2.6' // Sets the version of python to use, will search your PATH to get the location
+        // pythonVersion = '2.7' // Sets the version of python to use, will search your PATH to get the location
         // systemPythonInterpreter = file("/path/to/python2.7") // used to force an interpreter to be used to build the venv
     }
 }
@@ -73,7 +73,7 @@ This plugin also enforces a set of allowed Python versions.  If you choose a
 Python version that is not allowed, you will see an error messages such as:
 
 ```
-> Python 3.2 not allowed; choose from [2.6, 2.7, 3.4, 3.5, 3.6]
+> Python 3.2 not allowed; choose from [2.7, 3.4, 3.5, 3.6]
 ```
 
 If you see this error message, you must adjust your `pythonVersion` setting to

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/PythonExtension.groovy
@@ -63,7 +63,6 @@ class PythonExtension {
 
     /** A way to define forced versions of libraries */
     public Map<String, Map<String, String>> forcedVersions = [
-        'argparse'      : ['group': 'pypi', 'name': 'argparse', 'version': '1.4.0'],
         'flake8'        : ['group': 'pypi', 'name': 'flake8', 'version': '2.6.2'],
         'pex'           : ['group': 'pypi', 'name': 'pex', 'version': '1.4.7'],
         'pip'           : ['group': 'pypi', 'name': 'pip', 'version': '18.0'],

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersions.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersions.java
@@ -34,8 +34,8 @@ public class PythonDefaultVersions implements Serializable {
     }
 
     public PythonDefaultVersions(Collection<String> allowedVersions) {
-        defaultPython2Version = "2.6";
-        defaultPython3Version = "3.5";
+        defaultPython2Version = "2.7";
+        defaultPython3Version = "3.7";
         this.allowedVersions = allowedVersions;
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPexDistributionPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPexDistributionPlugin.java
@@ -41,13 +41,6 @@ public class PythonPexDistributionPlugin extends PythonBasePlugin {
         ExtensionUtils.maybeCreateWheelExtension(project);
         final DeployableExtension deployableExtension = ExtensionUtils.maybeCreateDeployableExtension(project);
 
-        project.afterEvaluate(ignored -> {
-            if (settings.getDetails().getPythonVersion().getPythonMajorMinor().equals("2.6")) {
-                project.getDependencies().add(StandardTextValues.CONFIGURATION_BUILD_REQS.getValue(),
-                    extension.forcedVersions.get("argparse"));
-            }
-        });
-
         project.getDependencies().add(StandardTextValues.CONFIGURATION_BUILD_REQS.getValue(),
             extension.forcedVersions.get("pex"));
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonWheelDistributionPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonWheelDistributionPlugin.java
@@ -25,7 +25,7 @@ public class PythonWheelDistributionPlugin extends PythonBasePlugin {
     @Override
     public void applyTo(final Project project) {
         // XXX: This needs to be adjusted to work with a build matrix one day. Until
-        // that is ready, we always assume pure Python 2.6 on Linux.
+        // that is ready, we always assume pure Python 2.7 on Linux.
         String version = project.getVersion().toString().replace("-", "_");
         String name = project.getName().replace("-", "_");
         final File wheelArtifact = new File(project.getProjectDir(), "/dist/" + name + "-" + version + "-py2-none-any.whl");

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -80,24 +80,6 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
     @TaskAction
     void buildWheelsTask() {
         buildWheels(project, DependencyOrder.getConfigurationFiles(installFileCollection), getPythonDetails())
-
-        /*
-         * If pexDependencies are empty or its wheels are already
-         * installed from python configuration, the call below will
-         * have no effect.
-         */
-        List<File> pexDependencies = []
-
-        /*
-         * In Python <=2.6, argparse is not part of the standard library
-         * and Pex requires it, so we need to include it as a dependency
-         */
-        project.configurations.build.files.each { file ->
-            if (getPythonDetails().pythonVersion.pythonMajorMinor == '2.6' && file.name.contains('argparse')) {
-                pexDependencies.add(file)
-            }
-        }
-        buildWheels(project, pexDependencies.sort(), getPythonDetails())
     }
 
     /**

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pip/PipFreezeAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pip/PipFreezeAction.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 
@@ -46,11 +45,6 @@ public class PipFreezeAction {
         developmentDependencies.addAll(configurationToSet(project, StandardTextValues.CONFIGURATION_TEST.getValue()));
 
         developmentDependencies.removeAll(configurationToSet(project, StandardTextValues.CONFIGURATION_PYTHON.getValue()));
-
-        if (Objects.equals(settings.getDetails().getPythonVersion().getPythonMajorMinor(), "2.6")
-            && developmentDependencies.contains("argparse")) {
-            developmentDependencies.remove("argparse");
-        }
 
         final ByteArrayOutputStream requirements = new ByteArrayOutputStream();
 

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/DefaultPythonDetailsUnixTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/DefaultPythonDetailsUnixTest.groovy
@@ -66,12 +66,12 @@ class DefaultPythonDetailsUnixTest extends Specification {
         thrown(RuntimeException)
     }
 
-    @Requires({ new File('/usr/bin/python2.6').exists() })
+    @Requires({ new File('/usr/bin/python2.7').exists() })
     def "interpreterPath with major only 2 interpreterVersion"() {
         when: "we request only the major version 2"
         details.pythonVersion = '2'
         then: "we get the default major version 2 cleanpython or the system default if cleanptyhon is not installed"
-        details.getSystemPythonInterpreter().path.endsWith("2.6")
+        details.getSystemPythonInterpreter().path.endsWith("2.7")
     }
 
     @Requires({ new File('/usr/bin/python3.5').exists() })
@@ -80,15 +80,6 @@ class DefaultPythonDetailsUnixTest extends Specification {
         details.pythonVersion = '3'
         then: "we get the default major version 3 cleanpython or the system default if cleanpython is not installed"
         details.getSystemPythonInterpreter().path.endsWith("3.5")
-    }
-
-    @Requires({ new File('/usr/bin/python2.7').exists() && new File('/usr/bin/python2.6').exists() })
-    def "interpreterPath with systemPython set"() {
-        when: "we have old systemPython setting"
-        details.pythonVersion = '2.6'
-        details.systemPythonInterpreter = '/usr/bin/python2.7'
-        then: "we get that as interpreter path"
-        details.systemPythonInterpreter.absolutePath == '/usr/bin/python2.7'
     }
 
     def "interpreterPath with nonsense interpreterVersion"() {

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/DefaultPythonDetailsWindowsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/DefaultPythonDetailsWindowsTest.groovy
@@ -84,8 +84,8 @@ class DefaultPythonDetailsWindowsTest extends Specification {
     def "interpreterPath with major only 2 interpreterVersion"() {
         when: "we request only the major version 2"
         settings.pythonVersion = '2'
-        then: "we get the default major version 2 cleanpython or the system default if cleanptyhon is not installed"
-        settings.getSystemPythonInterpreter().path.endsWith("2.6.exe")
+        then: "we get the default major version 2 cleanpython or the system default if cleanpython is not installed"
+        settings.getSystemPythonInterpreter().path.endsWith("2.7.exe")
     }
 
     def "interpreterPath with major only 3 interpreterVersion"() {
@@ -97,8 +97,9 @@ class DefaultPythonDetailsWindowsTest extends Specification {
 
     def "interpreterPath with systemPython set"() {
         when: "we have old systemPython setting"
-        settings.pythonVersion = '2.6'
-        def path = Paths.get(temporaryFolder.getRoot().absolutePath, 'python3.5.1', DefaultVirtualEnvironment.getPythonApplicationDirectory(), 'python3.5.exe').toString()
+        settings.pythonVersion = '2.7'
+        def path = Paths.get(temporaryFolder.getRoot().absolutePath, 'python3.5.1',
+                             DefaultVirtualEnvironment.getPythonApplicationDirectory(), 'python3.5.exe').toString()
         settings.systemPythonInterpreter = path
         then: "we get that as interpreter path"
         settings.systemPythonInterpreter.absolutePath == path

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersionsTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/extension/PythonDefaultVersionsTest.groovy
@@ -29,8 +29,8 @@ class PythonDefaultVersionsTest extends Specification {
         where:
         a       || b
         '1.5.2' || '1.5.2'
-        '2'     || '2.6'
-        '3'     || '3.5'
+        '2'     || '2.7'
+        '3'     || '3.7'
     }
 
     @Unroll
@@ -53,8 +53,8 @@ class PythonDefaultVersionsTest extends Specification {
         a     || b
         '3.5' || '3.5'
         '2.7' || '2.7'
-        '3'   || '3.5'
-        '2'   || '2.6'
+        '3'   || '3.7'
+        '2'   || '2.7'
     }
 
     @Unroll
@@ -88,7 +88,7 @@ class PythonDefaultVersionsTest extends Specification {
     @Unroll
     def 'test acceptable #a normalizes to #b with whitelist #c'() {
         expect:
-        new PythonDefaultVersions('2.6', '3.5', c).normalize(a) == b
+        new PythonDefaultVersions('2.7', '3.5', c).normalize(a) == b
 
         where:
         a     | c                            || b
@@ -99,7 +99,7 @@ class PythonDefaultVersionsTest extends Specification {
     @Unroll
     def 'test unacceptable #a with whitelist #b'() {
         when:
-        new PythonDefaultVersions('2.6', '3.5', b).normalize(a)
+        new PythonDefaultVersions('2.7', '3.5', b).normalize(a)
 
         then:
         def e = thrown(GradleException)

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/plugin/PythonPluginTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/plugin/PythonPluginTest.groovy
@@ -84,7 +84,7 @@ class PythonPluginTest extends Specification {
         def details = project.getExtensions().getByType(PythonExtension).getDetails()
 
         if (OperatingSystem.current() == OperatingSystem.WINDOWS) {
-            def folder = temporaryFolder.newFolder("python2.6", 'bin')
+            def folder = temporaryFolder.newFolder("python2.7", 'bin')
             details.prependExecutableDirectory(buildPythonExec(folder, WindowsBinaryUnpacker.PythonVersion.PYTHON_26))
         }
 

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/pip/PipFreezeOutputParserTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/util/pip/PipFreezeOutputParserTest.groovy
@@ -53,12 +53,12 @@ class PipFreezeOutputParserTest extends Specification {
         expect:
         PipFreezeOutputParser.getDependencies(['pbr', 'Babel', 'pep8', 'py', 'setuptools', 'pytest-xdist', 'Jinja2', 'flake8', 'snowballstemmer',
                                                'alabaster', 'sphinx_rtd_theme', 'Pygments', 'pytest-cov', 'pip', 'mccabe', 'docutils', 'coverage', 'pex',
-                                               'six', 'setuptools-git', 'pyflakes', 'pytest', 'wheel', 'imagesize', 'argparse', 'Sphinx', 'colorama',
+                                               'six', 'setuptools-git', 'pyflakes', 'pytest', 'wheel', 'imagesize', 'Sphinx', 'colorama',
                                                'pytz'], freezeOutput) == ['testProject': 'unspecified', 'MP': '1.2.3-TESTSUFFIX']
 
         PipFreezeOutputParser.getDependencies(['pbr', 'Babel', 'pep8', 'py', 'setuptools', 'pytest-xdist', 'Jinja2', 'flake8', 'snowballstemmer',
                                                'alabaster', 'sphinx_rtd_theme', 'Pygments', 'pip', 'mccabe', 'docutils', 'coverage', 'pex',
-                                               'six', 'setuptools-git', 'pyflakes', 'pytest', 'wheel', 'imagesize', 'argparse', 'Sphinx', 'colorama',
+                                               'six', 'setuptools-git', 'pyflakes', 'pytest', 'wheel', 'imagesize', 'Sphinx', 'colorama',
                                                'pytz'], freezeOutput) == ['testProject': 'unspecified', 'MP': '1.2.3-TESTSUFFIX', 'pytest-cov': '2.2.1']
     }
 


### PR DESCRIPTION
* Bump minimum Python to 2.7
* Set default Python 3 version to 3.7
* Drop the need for argparse

Note that I did not bump the minor version number, but I can do that if you think it's appropriate.