### PR TITLE
Add options to pivy-importer to exclude extras.

### DIFF
--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/ImporterCLI.java
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/ImporterCLI.java
@@ -54,6 +54,11 @@ public class ImporterCLI {
             root.setLevel(Level.WARN);
         }
 
+        if (line.hasOption("debug")) {
+            Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+            root.setLevel(Level.DEBUG);
+        }
+
         if (!line.hasOption("repo")) {
             throw new RuntimeException("Unable to continue, no repository location given on the command line (use the --repo switch)");
         }
@@ -92,7 +97,12 @@ public class ImporterCLI {
                 throw new IllegalArgumentException(errMsg);
             }
 
-            artifactDownloader.download(line.hasOption("latest"), line.hasOption("pre"), line.hasOption("lenient"));
+            artifactDownloader.download(
+                line.hasOption("latest"),
+                line.hasOption("pre"),
+                line.hasOption("extras"),
+                line.hasOption("lenient")
+            );
         }
     }
 
@@ -100,10 +110,11 @@ public class ImporterCLI {
                                                       DependencyDownloader artifactDownloader,
                                                       boolean latestVersions,
                                                       boolean allowPreReleases,
+                                                      boolean fetchExtras,
                                                       boolean lenient) {
 
         artifactDownloader.getProcessedDependencies().addAll(processedDependencies);
-        artifactDownloader.download(latestVersions, allowPreReleases, lenient);
+        artifactDownloader.download(latestVersions, allowPreReleases, fetchExtras, lenient);
         processedDependencies.addAll(artifactDownloader.getProcessedDependencies());
     }
 
@@ -141,6 +152,12 @@ public class ImporterCLI {
             .desc("Sets logging level to WARN")
             .build();
 
+        Option debug = Option.builder()
+            .longOpt("debug")
+            .numberOfArgs(0)
+            .desc("Sets logging level to DEBUG")
+            .build();
+
         Option force = Option.builder()
             .longOpt("force")
             .numberOfArgs(Option.UNLIMITED_VALUES)
@@ -160,6 +177,12 @@ public class ImporterCLI {
             .desc("Allows pre-releases (alpha, beta, release candidates)")
             .build();
 
+        Option extras = Option.builder()
+            .longOpt("extras")
+            .numberOfArgs(0)
+            .desc("Gets extra dependencies for each dependency")
+            .build();
+
         Option lenient = Option.builder()
             .longOpt("lenient")
             .numberOfArgs(0)
@@ -170,9 +193,11 @@ public class ImporterCLI {
         options.addOption(replacement);
         options.addOption(repo);
         options.addOption(quiet);
+        options.addOption(debug);
         options.addOption(force);
         options.addOption(latest);
         options.addOption(pre);
+        options.addOption(extras);
         options.addOption(lenient);
 
         return options;

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencyDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/DependencyDownloader.groovy
@@ -44,18 +44,19 @@ abstract class DependencyDownloader {
         dependencies.add(project)
     }
 
-    def download(boolean latestVersions, boolean allowPreReleases, boolean lenient) {
+    def download(boolean latestVersions, boolean allowPreReleases, boolean fetchExtras, boolean lenient) {
         while (!dependencies.isEmpty()) {
             def dep = dependencies.poll()
             if (dep in processedDependencies) {
                 continue
             }
-            downloadDependency(dep, latestVersions, allowPreReleases, lenient)
+            downloadDependency(dep, latestVersions, allowPreReleases, fetchExtras, lenient)
             processedDependencies.add(dep)
         }
     }
 
-    abstract downloadDependency(String dep, boolean latestVersions, boolean allowPreReleases, boolean lenient)
+    abstract downloadDependency(
+        String dep, boolean latestVersions, boolean allowPreReleases, boolean fetchExtras, boolean lenient)
 
     protected static File downloadArtifact(File destDir, String url) {
 

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
@@ -35,7 +35,9 @@ class SdistDownloader extends DependencyDownloader {
     }
 
     @Override
-    def downloadDependency(String dep, boolean latestVersions, boolean allowPreReleases, boolean lenient) {
+    def downloadDependency(
+        String dep, boolean latestVersions, boolean allowPreReleases, boolean fetchExtras, boolean lenient) {
+
         def (String name, String version) = dep.split(":")
 
         def projectDetails = cache.getDetails(name, lenient)
@@ -63,9 +65,11 @@ class SdistDownloader extends DependencyDownloader {
         destDir.mkdirs()
 
         def sdistArtifact = downloadArtifact(destDir, sdistDetails.url)
-        def packageDependencies = new SourceDistPackage(name, version, sdistArtifact, cache, dependencySubstitution).getDependencies(latestVersions, allowPreReleases, lenient)
+        def packageDependencies = new SourceDistPackage(name, version, sdistArtifact, cache, dependencySubstitution)
+            .getDependencies(latestVersions, allowPreReleases, fetchExtras, lenient)
 
-        new IvyFileWriter(name, version, SOURCE_DIST_PACKAGE_TYPE, [sdistDetails]).writeIvyFile(destDir, packageDependencies)
+        new IvyFileWriter(name, version, SOURCE_DIST_PACKAGE_TYPE, [sdistDetails])
+            .writeIvyFile(destDir, packageDependencies)
 
         packageDependencies.each { key, value ->
             dependencies.addAll(value)

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/WheelsDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/WheelsDownloader.groovy
@@ -47,7 +47,9 @@ class WheelsDownloader extends DependencyDownloader {
     }
 
     @Override
-    def downloadDependency(String dep, boolean latestVersions, boolean allowPreReleases, boolean lenient) {
+    def downloadDependency(
+            String dep, boolean latestVersions, boolean allowPreReleases, boolean fetchExtras, boolean lenient) {
+
         def (String name, String version, String classifier) = dep.split(":")
 
         name = translateNameToWheelFormat(name)
@@ -78,7 +80,8 @@ class WheelsDownloader extends DependencyDownloader {
         destDir.mkdirs()
 
         def wheelArtifact = downloadArtifact(destDir, wheelDetails.url)
-        def packageDependencies = new WheelsPackage(name, version, wheelArtifact, cache, dependencySubstitution).getDependencies(latestVersions, allowPreReleases, lenient)
+        def packageDependencies = new WheelsPackage(name, version, wheelArtifact, cache, dependencySubstitution)
+            .getDependencies(latestVersions, allowPreReleases, fetchExtras, lenient)
 
         log.debug("The dependencies of package $project: is ${packageDependencies.toString()}")
         new IvyFileWriter(name, version, BINARY_DIST_PACKAGE_TYPE, [wheelDetails])
@@ -87,10 +90,11 @@ class WheelsDownloader extends DependencyDownloader {
         packageDependencies.each { key, value ->
             List<String> sdistDependencies = value
             for (String sdist : sdistDependencies) {
-                DependencyDownloader sdistDownloader = new SdistDownloader(sdist, ivyRepoRoot,
-                    dependencySubstitution, processedDependencies)
+                DependencyDownloader sdistDownloader = new SdistDownloader(
+                    sdist, ivyRepoRoot, dependencySubstitution, processedDependencies)
 
-                ImporterCLI.pullDownPackageAndDependencies(processedDependencies, sdistDownloader, latestVersions, allowPreReleases, lenient)
+                ImporterCLI.pullDownPackageAndDependencies(
+                    processedDependencies, sdistDownloader, latestVersions, allowPreReleases, fetchExtras, lenient)
             }
         }
     }

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/PythonPackage.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/PythonPackage.groovy
@@ -45,6 +45,7 @@ abstract class PythonPackage {
 
     abstract Map<String, List<String>> getDependencies(boolean latestVersions,
                                                        boolean allowPreReleases,
+                                                       boolean fetchExtras,
                                                        boolean lenient)
 
     protected String explodeZipForTargetEntry(String entryName) {

--- a/pivy-importer/src/test/groovy/com/linkedin/python/importer/deps/DependencyDownloaderTest.groovy
+++ b/pivy-importer/src/test/groovy/com/linkedin/python/importer/deps/DependencyDownloaderTest.groovy
@@ -23,7 +23,8 @@ import spock.lang.Specification
 @InheritConstructors
 class TestDependencyDownloader extends DependencyDownloader {
     @Override
-    String downloadDependency(String dep, boolean latestVersions, boolean allowPreReleases, boolean lenient) {
+    String downloadDependency(
+            String dep, boolean latestVersions, boolean allowPreReleases, boolean fetchExtras, boolean lenient) {
         return "Successfully download dependency in unittest scenario!"
     }
 }
@@ -61,6 +62,7 @@ class DependencyDownloaderTest extends Specification {
         Set<String> testProcessedDependencies = new HashSet<>()
         boolean testLatestVersions = true
         boolean testAllowPreReleases = false
+        boolean testFetchExtras = false
         boolean testLenient = true
         TestDependencyDownloader dependencyDownloader =
             new TestDependencyDownloader(
@@ -71,7 +73,7 @@ class DependencyDownloaderTest extends Specification {
             )
 
         when:
-        dependencyDownloader.download(testLatestVersions, testAllowPreReleases, testLenient)
+        dependencyDownloader.download(testLatestVersions, testAllowPreReleases, testFetchExtras, testLenient)
 
         then:
         assert dependencyDownloader.dependencies.isEmpty()

--- a/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/PythonPackageTest.groovy
+++ b/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/PythonPackageTest.groovy
@@ -25,6 +25,7 @@ class TestPythonPackage extends PythonPackage {
     @Override
     Map<String, List<String>> getDependencies(boolean latestVersions,
                                               boolean allowPreReleases,
+                                              boolean fetchExtras,
                                               boolean lenient) {
         return [:]
     }


### PR DESCRIPTION
We should be able to exclude all extras.
Since that is the default in our usage, we're making it the default
usage in pivy-importer too.
Also, we should be able to debug what pivy-importer is doing.