### PR TITLE
Simplify test setup for wheel cache.

### DIFF
--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCacheTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCacheTest.groovy
@@ -25,13 +25,20 @@ class FileBackedWheelCacheTest extends Specification {
     @Rule
     TemporaryFolder temporaryFolder
 
-    def "can find Sphinx-1.6.3"() {
-        setup:
-        def wheelCache = temporaryFolder.newFolder('wheel-cache')
-        def pythonExec = temporaryFolder.newFile('python')
+    private File wheelCache
+    private File pythonExec
+    private FileBackedWheelCache cache
+
+    void setup() {
+        wheelCache = temporaryFolder.newFolder('wheel-cache')
+        pythonExec = temporaryFolder.newFile('python')
         def formats = new DefaultPythonAbiContainer()
         formats.addSupportedAbi(new AbiDetails(pythonExec, 'py2', 'none', 'any'))
-        FileBackedWheelCache cache = new FileBackedWheelCache(wheelCache, formats)
+        cache = new FileBackedWheelCache(wheelCache, formats)
+    }
+
+    def "can find Sphinx-1.6.3"() {
+        setup:
         new File(wheelCache, 'Sphinx-1.6.3-py2.py3-none-any.whl').createNewFile()
 
         expect:
@@ -40,11 +47,6 @@ class FileBackedWheelCacheTest extends Specification {
 
     def "does not accept partially matching version"() {
         setup: "we have a package with the same version prefix but not matching exactly"
-        def wheelCache = temporaryFolder.newFolder('wheel-cache')
-        def pythonExec = temporaryFolder.newFile('python')
-        def formats = new DefaultPythonAbiContainer()
-        formats.addSupportedAbi(new AbiDetails(pythonExec, 'py2', 'none', 'any'))
-        FileBackedWheelCache cache = new FileBackedWheelCache(wheelCache, formats)
         new File(wheelCache, 'my_special_package-0.0.20-py2.py3-none-any.whl').createNewFile()
 
         expect: "the partial match between 0.0.2 and 0.0.20 does not find the wheel"
@@ -53,11 +55,6 @@ class FileBackedWheelCacheTest extends Specification {
 
     def "finds the exact matching version"() {
         setup: "we have an exact and partial match"
-        def wheelCache = temporaryFolder.newFolder('wheel-cache')
-        def pythonExec = temporaryFolder.newFile('python')
-        def formats = new DefaultPythonAbiContainer()
-        formats.addSupportedAbi(new AbiDetails(pythonExec, 'py2', 'none', 'any'))
-        FileBackedWheelCache cache = new FileBackedWheelCache(wheelCache, formats)
         new File(wheelCache, 'my_special_package-0.0.30-py2.py3-none-any.whl').createNewFile()
         new File(wheelCache, 'my_special_package-0.0.3-py2.py3-none-any.whl').createNewFile()
 


### PR DESCRIPTION
Extract the setup code out of the test methods to get the test code DRY.