### PR TITLE
Add a mypy task

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,8 @@
+# pygradle news #
+
+* 2018-11-09
+  - Added a default `mypy` task which you can enable by setting
+    `python.mypy.run = true` in your `build.gradle` file.
+
+* Earlier
+  - Lots!

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
@@ -1,0 +1,13 @@
+package com.linkedin.gradle.python.extension;
+
+public class MypyExtension {
+    private boolean run;
+
+    public boolean isRun() {
+        return run;
+    }
+
+    public void setRun(boolean run) {
+        this.run = run;
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.gradle.python.extension;
 
 public class MypyExtension {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPexDistributionPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPexDistributionPlugin.java
@@ -44,7 +44,6 @@ public class PythonPexDistributionPlugin extends PythonBasePlugin {
         project.getDependencies().add(StandardTextValues.CONFIGURATION_BUILD_REQS.getValue(),
             extension.forcedVersions.get("pex"));
 
-
         /*
          * Build wheels.
          *

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
@@ -16,10 +16,12 @@
 package com.linkedin.gradle.python.plugin.internal;
 
 import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.extension.MypyExtension;
 import com.linkedin.gradle.python.tasks.AbstractPythonMainSourceDefaultTask;
 import com.linkedin.gradle.python.tasks.AbstractPythonTestSourceDefaultTask;
 import com.linkedin.gradle.python.tasks.CheckStyleGeneratorTask;
 import com.linkedin.gradle.python.tasks.Flake8Task;
+import com.linkedin.gradle.python.tasks.MypyTask;
 import com.linkedin.gradle.python.tasks.PyCoverageTask;
 import com.linkedin.gradle.python.tasks.PyTestTask;
 import com.linkedin.gradle.python.util.ExtensionUtils;
@@ -32,6 +34,7 @@ import static com.linkedin.gradle.python.util.StandardTextValues.TASK_COVERAGE;
 import static com.linkedin.gradle.python.util.StandardTextValues.TASK_FLAKE;
 import static com.linkedin.gradle.python.util.StandardTextValues.TASK_INSTALL_BUILD_REQS;
 import static com.linkedin.gradle.python.util.StandardTextValues.TASK_INSTALL_PROJECT;
+import static com.linkedin.gradle.python.util.StandardTextValues.TASK_MYPY;
 import static com.linkedin.gradle.python.util.StandardTextValues.TASK_PYTEST;
 
 public class ValidationPlugin implements Plugin<Project> {
@@ -79,6 +82,15 @@ public class ValidationPlugin implements Plugin<Project> {
          */
         project.getTasks().create(TASK_FLAKE.getValue(), Flake8Task.class,
             task -> task.onlyIf(it -> project.file(settings.srcDir).exists() || project.file(settings.testDir).exists()));
+
+        /*
+         * Run mypy.
+         *
+         * This uses the mypy.ini file if present to configure mypy.
+         */
+        MypyExtension mypy = ExtensionUtils.maybeCreate(project, "mypy", MypyExtension.class);
+        project.getTasks().create(TASK_MYPY.getValue(), MypyTask.class,
+            task -> task.onlyIf(it -> project.file(settings.srcDir).exists() && mypy.isRun()));
 
         /*
          * Create checkstyle styled report from flake

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/MypyTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/MypyTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.tasks;
+
+import com.linkedin.gradle.python.extension.PythonDetails;
+import org.gradle.process.ExecResult;
+
+
+public class MypyTask extends AbstractPythonMainSourceDefaultTask {
+
+    public void preExecution() {
+        PythonDetails mypyDetails = getPythonDetails();
+        args(mypyDetails.getVirtualEnvironment().findExecutable("mypy").getAbsolutePath());
+        args(getPythonExtension().srcDir);
+    }
+
+    public void processResults(ExecResult results) {
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/StandardTextValues.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/StandardTextValues.java
@@ -16,8 +16,8 @@
 package com.linkedin.gradle.python.util;
 
 /**
- * CodeNarc is complaining that some classes exceed 350 lines.  TO fall into compliance with CodeNarc, the standard values
- * are being moved to this enum.  Its an Enum rather than an interface because according to CodeNarc, interfaces of nothing
+ * CodeNarc is complaining that some classes exceed 350 lines.  To fall into compliance with CodeNarc, the standard values
+ * are being moved to this enum.  It's an Enum rather than an interface because according to CodeNarc, interfaces of nothing
  * but constants is now taboo.
  */
 public enum StandardTextValues {
@@ -42,6 +42,7 @@ public enum StandardTextValues {
     TASK_INSTALL_PROJECT("installProject"),
     TASK_INSTALL_PYTHON_REQS("installPythonRequirements"),
     TASK_INSTALL_TEST_REQS("installTestRequirements"),
+    TASK_MYPY("mypy"),
     TASK_PACKAGE_DOCS("packageDocs"),
     TASK_PACKAGE_JSON_DOCS("packageJsonDocs"),
     TASK_PYTEST("pytest"),


### PR DESCRIPTION
* We deliberately (for now) don't pull in mypy dependency, because it's moving
  fast enough that it would likely be inconvenient to update.  Once it settles
  down (and if there's demand), we can add it later.
* Set `python.mypy.run = true` in your `build.gradle` to enable the task.
* Added the most minimal changelog file imaginable.
* Drive-by fix a typo.