### PR TITLE
adding isPlainOrVerbose condition for installed wheels

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelAction.java
@@ -127,7 +127,9 @@ public class PipWheelAction extends AbstractPipAction {
         });
 
         if (tree.getFiles().size() >= 1) {
-            logger.lifecycle("Skipping {} wheel - Installed", packageInfo.toShortHand());
+            if (PythonHelpers.isPlainOrVerbose(project)) {
+                logger.lifecycle("Skipping {} wheel - Installed", packageInfo.toShortHand());
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
Fixing buildWheels task prints verbose output for installed wheels.  Tested locally by publishing an artifact and consuming within an internal product.