### PR TITLE
Rename mypy task.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/StandardTextValues.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/StandardTextValues.java
@@ -42,7 +42,7 @@ public enum StandardTextValues {
     TASK_INSTALL_PROJECT("installProject"),
     TASK_INSTALL_PYTHON_REQS("installPythonRequirements"),
     TASK_INSTALL_TEST_REQS("installTestRequirements"),
-    TASK_MYPY("mypy"),
+    TASK_MYPY("runMypy"),
     TASK_PACKAGE_DOCS("packageDocs"),
     TASK_PACKAGE_JSON_DOCS("packageJsonDocs"),
     TASK_PYTEST("pytest"),


### PR DESCRIPTION
Rename mypy task to avoid conflict with some currently used custom
tasks. We can revisit and simplify it later if needed once custom
tasks are replaced with this feature.