### PR TITLE
Make enabling coverage a little easier

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/CoverageExtension.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/CoverageExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.extension;
+
+public class CoverageExtension {
+    private boolean run;
+
+    public boolean isRun() {
+        return run;
+    }
+
+    public void setRun(boolean run) {
+        this.run = run;
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
@@ -17,6 +17,7 @@ package com.linkedin.gradle.python.plugin.internal;
 
 import com.linkedin.gradle.python.PythonExtension;
 import com.linkedin.gradle.python.extension.MypyExtension;
+import com.linkedin.gradle.python.extension.CoverageExtension;
 import com.linkedin.gradle.python.tasks.AbstractPythonMainSourceDefaultTask;
 import com.linkedin.gradle.python.tasks.AbstractPythonTestSourceDefaultTask;
 import com.linkedin.gradle.python.tasks.CheckStyleGeneratorTask;
@@ -72,8 +73,13 @@ public class ValidationPlugin implements Plugin<Project> {
          *
          * This uses the ``setup.cfg`` if present to configure py.test.
          */
+        CoverageExtension cov = ExtensionUtils.maybeCreate(project, "coverage", CoverageExtension.class);
         project.getTasks().create(TASK_COVERAGE.getValue(), PyCoverageTask.class,
-            task -> task.onlyIf(it -> project.file(settings.testDir).exists()));
+            task -> task.onlyIf(it -> project.file(settings.testDir).exists() && cov.isRun()));
+
+        // Make task "check" depend on coverage task.
+        project.getTasks().getByName(TASK_CHECK.getValue())
+            .dependsOn(project.getTasks().getByName(TASK_COVERAGE.getValue()));
 
         /*
          * Run flake8.
@@ -92,7 +98,7 @@ public class ValidationPlugin implements Plugin<Project> {
         project.getTasks().create(TASK_MYPY.getValue(), MypyTask.class,
             task -> task.onlyIf(it -> project.file(settings.srcDir).exists() && mypy.isRun()));
 
-        // Make task "check" depend on mypy task
+        // Make task "check" depend on mypy task.
         project.getTasks().getByName(TASK_CHECK.getValue())
             .dependsOn(project.getTasks().getByName(TASK_MYPY.getValue()));
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
@@ -75,13 +75,13 @@ public class ValidationPlugin implements Plugin<Project> {
          */
         CoverageExtension cov = ExtensionUtils.maybeCreate(project, "coverage", CoverageExtension.class);
         project.getTasks().create(TASK_COVERAGE.getValue(), PyCoverageTask.class,
-            task -> task.onlyIf(it -> project.file(settings.testDir).exists() &&
+            task -> task.onlyIf(it -> project.file(settings.testDir).exists()
                                 /* The test suite and other environments run
                                  * the coverage task explicitly, so check
                                  * whether the flag is set *or* its been
                                  * explicitly invoked.
                                  */
-                                (cov.isRun() || project.getGradle().getStartParameter().getTaskNames().contains("coverage"))
+                                && (cov.isRun() || project.getGradle().getStartParameter().getTaskNames().contains("coverage"))
                                 ));
 
         // Make task "check" depend on coverage task.

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
@@ -75,7 +75,14 @@ public class ValidationPlugin implements Plugin<Project> {
          */
         CoverageExtension cov = ExtensionUtils.maybeCreate(project, "coverage", CoverageExtension.class);
         project.getTasks().create(TASK_COVERAGE.getValue(), PyCoverageTask.class,
-            task -> task.onlyIf(it -> project.file(settings.testDir).exists() && cov.isRun()));
+            task -> task.onlyIf(it -> project.file(settings.testDir).exists() &&
+                                /* The test suite and other environments run
+                                 * the coverage task explicitly, so check
+                                 * whether the flag is set *or* its been
+                                 * explicitly invoked.
+                                 */
+                                (cov.isRun() || project.getGradle().getStartParameter().getTaskNames().contains("coverage"))
+                                ));
 
         // Make task "check" depend on coverage task.
         project.getTasks().getByName(TASK_CHECK.getValue())


### PR DESCRIPTION
Taking a cue from the recent mypy extension, add CoverageExtension class with
a `run` property.  Make the check task depend on the coverage task so that it
is run automatically, but only if `run` is true.  Now I can simplify running
coverage by just adding this to my build.gradle:

```
python {
  coverage.run = true
}
```

Closes #182