### PR TITLE
Added lenient decorator for Pypi cache to decouple args specific behaviour

### DIFF
--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/deps/SdistDownloader.groovy
@@ -17,7 +17,9 @@ package com.linkedin.python.importer.deps
 
 import com.linkedin.python.importer.distribution.SourceDistPackage
 import com.linkedin.python.importer.ivy.IvyFileWriter
+import com.linkedin.python.importer.pypi.cache.ApiCache
 import groovy.util.logging.Slf4j
+
 import java.nio.file.Paths
 
 @Slf4j
@@ -25,13 +27,9 @@ class SdistDownloader extends DependencyDownloader {
     static final String SOURCE_DIST_PACKAGE_TYPE = "sdist"
     static final String SOURCE_DIST_ORG = "pypi"
 
-    SdistDownloader(
-        String project,
-        File ivyRepoRoot,
-        DependencySubstitution dependencySubstitution,
-        Set<String> processedDependencies) {
-
-        super(project, ivyRepoRoot, dependencySubstitution, processedDependencies)
+    SdistDownloader(String project, File ivyRepoRoot, DependencySubstitution dependencySubstitution,
+                    Set<String> processedDependencies, ApiCache cache) {
+        super(project, ivyRepoRoot, dependencySubstitution, processedDependencies, cache)
     }
 
     @Override
@@ -40,7 +38,7 @@ class SdistDownloader extends DependencyDownloader {
 
         def (String name, String version) = dep.split(":")
 
-        def projectDetails = cache.getDetails(name, lenient)
+        def projectDetails = cache.getDetails(name)
         // project name is illegal, which means we can't find any information about this project on PyPI
         if (projectDetails == null) {
             return
@@ -64,7 +62,7 @@ class SdistDownloader extends DependencyDownloader {
         def destDir = Paths.get(ivyRepoRoot.absolutePath, SOURCE_DIST_ORG, name, version).toFile()
         destDir.mkdirs()
 
-        def sdistArtifact = downloadArtifact(destDir, sdistDetails.url)
+        def sdistArtifact = pypiClient.downloadArtifact(destDir, sdistDetails.url)
         def packageDependencies = new SourceDistPackage(name, version, sdistArtifact, cache, dependencySubstitution)
             .getDependencies(latestVersions, allowPreReleases, fetchExtras, lenient)
 

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/PythonPackage.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/PythonPackage.groovy
@@ -16,8 +16,8 @@
 package com.linkedin.python.importer.distribution
 
 import com.linkedin.python.importer.deps.DependencySubstitution
-import com.linkedin.python.importer.pypi.PypiApiCache
 import com.linkedin.python.importer.pypi.VersionRange
+import com.linkedin.python.importer.pypi.cache.ApiCache
 import groovy.util.logging.Slf4j
 
 import java.util.zip.ZipFile
@@ -27,20 +27,20 @@ abstract class PythonPackage {
     protected final String moduleName
     protected final String version
     protected final File packageFile
-    protected final PypiApiCache pypiApiCache
+    protected final ApiCache pypiApiCache
     protected final DependencySubstitution dependencySubstitution
 
     protected PythonPackage(
         String moduleName,
         String version,
         File packageFile,
-        PypiApiCache pypiApiCache,
+        ApiCache pypiApiCache,
         DependencySubstitution dependencySubstitution) {
-            this.moduleName = moduleName
-            this.version = version
-            this.dependencySubstitution = dependencySubstitution
-            this.pypiApiCache = pypiApiCache
-            this.packageFile = packageFile
+        this.moduleName = moduleName
+        this.version = version
+        this.dependencySubstitution = dependencySubstitution
+        this.pypiApiCache = pypiApiCache
+        this.packageFile = packageFile
     }
 
     abstract Map<String, List<String>> getDependencies(boolean latestVersions,
@@ -60,8 +60,7 @@ abstract class PythonPackage {
 
     protected String parseDependencyFromRequire(String rawRequire,
                                                 boolean latestVersions,
-                                                boolean allowPreReleases,
-                                                boolean lenient) {
+                                                boolean allowPreReleases) {
 
         String removeSquareRequire
         if (rawRequire.contains('[')) {
@@ -140,7 +139,7 @@ abstract class PythonPackage {
             }
         }
 
-        def projectDetails = pypiApiCache.getDetails(moduleName, lenient)
+        def projectDetails = pypiApiCache.getDetails(moduleName)
 
         // project name is illegal, which means we can't find any information about this project on PyPI
         if (projectDetails == null) {

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/SourceDistPackage.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/SourceDistPackage.groovy
@@ -29,15 +29,14 @@ class SourceDistPackage extends PythonPackage {
                                               boolean fetchExtras,
                                               boolean lenient) {
 
-        return parseRequiresText(getRequiresTextFile(), latestVersions, allowPreReleases, fetchExtras, lenient)
+        return parseRequiresText(getRequiresTextFile(), latestVersions, allowPreReleases, fetchExtras)
     }
 
     @SuppressWarnings("ParameterReassignment")
     private Map<String, List<String>> parseRequiresText(String requires,
                                                         boolean latestVersions,
                                                         boolean allowPreReleases,
-                                                        boolean fetchExtras,
-                                                        boolean lenient) {
+                                                        boolean fetchExtras) {
         def dependenciesMap = [:]
         log.debug("requires: {}", requires)
         def config = 'default'
@@ -67,7 +66,7 @@ class SourceDistPackage extends PythonPackage {
                 if (inExtra && !fetchExtras) {
                     return
                 }
-                String dependency = parseDependencyFromRequire(line, latestVersions, allowPreReleases, lenient)
+                String dependency = parseDependencyFromRequire(line, latestVersions, allowPreReleases)
                 if (dependency != null) {
                     dependenciesMap[config] << dependency
                 }

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/WheelsPackage.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/distribution/WheelsPackage.groovy
@@ -35,12 +35,12 @@ class WheelsPackage extends PythonPackage {
 
         try {
             dependenciesMap = parseRuntimeRequiresFromMetadataJson(
-                runtimeRequiresFromMetadataJson, latestVersions, allowPreReleases, fetchExtras, lenient)
+                runtimeRequiresFromMetadataJson, latestVersions, allowPreReleases, fetchExtras)
         } catch(Exception e) {
             log.debug("Failed to parse Json Metadata for package ${packageFile.name}: ${e.message} " +
                 "Parsing METADATA text file instead.")
             dependenciesMap = parseDistRequiresFromMetadataText(
-                metadataText, latestVersions, allowPreReleases, fetchExtras, lenient)
+                metadataText, latestVersions, allowPreReleases, fetchExtras)
         }
 
         return dependenciesMap
@@ -50,8 +50,7 @@ class WheelsPackage extends PythonPackage {
         Map<String, List<String>> requires,
         boolean latestVersions,
         boolean allowPreReleases,
-        boolean fetchExtras,
-        boolean lenient) {
+        boolean fetchExtras) {
 
         def dependenciesMap = [:]
 
@@ -70,7 +69,7 @@ class WheelsPackage extends PythonPackage {
             log.debug("The requires of configuration $key: ${requiresList.toString()}")
             for (String require : requiresList) {
                 require = require.replaceAll(/[()]/, "")
-                String dependency = parseDependencyFromRequire(require, latestVersions, allowPreReleases, lenient)
+                String dependency = parseDependencyFromRequire(require, latestVersions, allowPreReleases)
                 if (dependency != null) {
                     dependenciesMap[config] << dependency
                 }
@@ -145,8 +144,7 @@ class WheelsPackage extends PythonPackage {
     private Map<String, List<String>> parseDistRequiresFromMetadataText(String requires,
                                                                         boolean latestVersions,
                                                                         boolean allowPreReleases,
-                                                                        boolean fetchExtras,
-                                                                        boolean lenient) {
+                                                                        boolean fetchExtras) {
         def dependenciesMap = [:]
         log.debug("Runtime requires of package ${packageFile.name} from Metadata text: {}", requires)
 
@@ -170,7 +168,7 @@ class WheelsPackage extends PythonPackage {
                     dependenciesMap[config] = []
                 }
 
-                String dependency = parseDependencyFromRequire(newLine, latestVersions, allowPreReleases, lenient)
+                String dependency = parseDependencyFromRequire(newLine, latestVersions, allowPreReleases)
                 if (dependency != null) {
                     dependenciesMap[config] << dependency
                 }

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/ApiCache.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/ApiCache.groovy
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.python.importer.pypi.cache
+
+import com.linkedin.python.importer.pypi.ProjectDetails
+
+interface ApiCache {
+    ProjectDetails getDetails(String project)
+}

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/ApiCaches.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/ApiCaches.groovy
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.python.importer.pypi.cache
+
+/**
+ * Utility to create Pypi cache objects depending on application configuration
+ */
+class ApiCaches {
+    static ApiCache create(boolean lenient) {
+        ApiCache cache = new PypiApiCache()
+        if (lenient) {
+            return new LenientPypiApiCacheDecorator(cache)
+        }
+        return cache
+    }
+}

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/LenientPypiApiCacheDecorator.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/LenientPypiApiCacheDecorator.groovy
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.python.importer.pypi.cache
+
+import com.linkedin.python.importer.pypi.ProjectDetails
+import groovy.util.logging.Slf4j
+
+/**
+ * Decorator suppresses original exceptions from real {@link PypiApiCache delegate}
+ */
+@Slf4j
+class LenientPypiApiCacheDecorator implements ApiCache {
+    final ApiCache delegate
+
+    LenientPypiApiCacheDecorator(ApiCache delegate) {
+        this.delegate = delegate
+    }
+
+    ProjectDetails getDetails(String project) {
+        try {
+            return delegate.getDetails(project)
+        } catch (IllegalArgumentException exception) {
+            log.error("${exception.message}")
+            return null
+        }
+    }
+}

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/PypiApiCache.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/pypi/cache/PypiApiCache.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.python.importer.pypi.cache
+
+import com.linkedin.python.importer.PypiClient
+import com.linkedin.python.importer.pypi.ProjectDetails
+import groovy.util.logging.Slf4j
+import org.apache.http.client.HttpResponseException
+
+@Slf4j
+class PypiApiCache implements ApiCache {
+    PypiClient pypiClient = new PypiClient()
+    Map<String, ProjectDetails> cache = [:].withDefault { String name ->
+        new ProjectDetails(pypiClient.downloadMetadata(name))
+    }
+
+    ProjectDetails getDetails(String project) {
+        try {
+            return cache.get(project)
+        } catch (HttpResponseException httpResponseException) {
+            String msg = "Package ${project} has an illegal module name, " +
+                "we are not able to find it on PyPI (https://pypi.org/pypi/$project/json)"
+            throw new IllegalArgumentException("$msg. ${httpResponseException.message}")
+        }
+    }
+}

--- a/pivy-importer/src/main/groovy/com/linkedin/python/importer/util/ProxyDetector.groovy
+++ b/pivy-importer/src/main/groovy/com/linkedin/python/importer/util/ProxyDetector.groovy
@@ -21,11 +21,11 @@ import org.apache.http.HttpHost
 @Slf4j
 class ProxyDetector {
 
-    private final static String HTTP_PROXY_HOST="http.proxyHost"
-    private final static String HTTP_PROXY_PORT="http.proxyPort"
+    private final static String HTTP_PROXY_HOST = "http.proxyHost"
+    private final static String HTTP_PROXY_PORT = "http.proxyPort"
 
     static maybeGetHttpProxy() {
-        int proxyPort=-1
+        int proxyPort = -1
 
         def proxyPortString = System.getProperty(HTTP_PROXY_PORT)
         def proxyHost = System.getProperty(HTTP_PROXY_HOST)

--- a/pivy-importer/src/test/groovy/com/linkedin/python/importer/deps/DependencyDownloaderTest.groovy
+++ b/pivy-importer/src/test/groovy/com/linkedin/python/importer/deps/DependencyDownloaderTest.groovy
@@ -15,6 +15,8 @@
  */
 package com.linkedin.python.importer.deps
 
+import com.linkedin.python.importer.pypi.cache.ApiCache
+import com.linkedin.python.importer.pypi.cache.PypiApiCache
 import groovy.transform.InheritConstructors
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -42,6 +44,7 @@ class DependencyDownloaderTest extends Specification {
         String testProject = "targetProject:1.1.1"
         DependencySubstitution testDependencySubstitution = new DependencySubstitution([:], [:])
         Set<String> testProcessedDependencies = new HashSet<>()
+        ApiCache cache = new PypiApiCache()
 
         when:
         TestDependencyDownloader dependencyDownloader =
@@ -49,7 +52,8 @@ class DependencyDownloaderTest extends Specification {
                 testProject,
                 testIvyRepoRoot,
                 testDependencySubstitution,
-                testProcessedDependencies)
+                testProcessedDependencies,
+                cache)
 
         then:
         assert dependencyDownloader.dependencies.contains(testProject)
@@ -60,6 +64,8 @@ class DependencyDownloaderTest extends Specification {
         String testProject = "targetProject:1.1.1"
         DependencySubstitution testDependencySubstitution = new DependencySubstitution([:], [:])
         Set<String> testProcessedDependencies = new HashSet<>()
+        ApiCache cache = new PypiApiCache()
+
         boolean testLatestVersions = true
         boolean testAllowPreReleases = false
         boolean testFetchExtras = false
@@ -70,6 +76,7 @@ class DependencyDownloaderTest extends Specification {
                 testIvyRepoRoot,
                 testDependencySubstitution,
                 testProcessedDependencies,
+                cache
             )
 
         when:

--- a/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/PythonPackageTest.groovy
+++ b/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/PythonPackageTest.groovy
@@ -16,7 +16,7 @@
 package com.linkedin.python.importer.distribution
 
 import com.linkedin.python.importer.deps.DependencySubstitution
-import com.linkedin.python.importer.pypi.PypiApiCache
+import com.linkedin.python.importer.pypi.cache.PypiApiCache
 import groovy.transform.InheritConstructors
 import spock.lang.Specification
 

--- a/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/SourceDistPacakgeTest.groovy
+++ b/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/SourceDistPacakgeTest.groovy
@@ -16,7 +16,7 @@
 package com.linkedin.python.importer.distribution
 
 import com.linkedin.python.importer.deps.DependencySubstitution
-import com.linkedin.python.importer.pypi.PypiApiCache
+import com.linkedin.python.importer.pypi.cache.PypiApiCache
 import spock.lang.Specification
 
 class SourceDistPacakgeTest extends Specification {

--- a/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/WheelsPackageTest.groovy
+++ b/pivy-importer/src/test/groovy/com/linkedin/python/importer/distribution/WheelsPackageTest.groovy
@@ -16,7 +16,7 @@
 package com.linkedin.python.importer.distribution
 
 import com.linkedin.python.importer.deps.DependencySubstitution
-import com.linkedin.python.importer.pypi.PypiApiCache
+import com.linkedin.python.importer.pypi.cache.PypiApiCache
 import spock.lang.Specification
 
 class WheelsPackageTest extends Specification {


### PR DESCRIPTION
The goal is to wrap all arg-specific processing (prerelease, extras, lenient, etc) with decorators to simplify common services and provide more flexibility for future extension. This is first part covering PypiApiCache only