### PR TITLE
Use --all with pip freeze.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pip/PipFreezeAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/pip/PipFreezeAction.java
@@ -48,12 +48,18 @@ public class PipFreezeAction {
 
         final ByteArrayOutputStream requirements = new ByteArrayOutputStream();
 
+        /*
+         * NOTE: It is very important to provide "--all" in the list of arguments
+         * to "pip freeze". Otherwise, setuptools, wheel, or pip would not be included
+         * even if required by runtime configuration "python".
+         */
         project.exec(execSpec -> {
             execSpec.environment(settings.getEnvironment());
             execSpec.commandLine(
                 settings.getDetails().getVirtualEnvInterpreter(),
                 settings.getDetails().getVirtualEnvironment().getPip(),
                 "freeze",
+                "--all",
                 "--disable-pip-version-check"
             );
             execSpec.setStandardOutput(requirements);


### PR DESCRIPTION
The pip freeze command must be run with the --all argument to ensure
that setuptools, wheel, or pip are packed into a zipapp if requested
as a runtime requirement (not just setup requirement).