### PR TITLE
Extend package settings API to support `isCustomized` checking.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/DefaultPackageSettings.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/DefaultPackageSettings.java
@@ -96,6 +96,12 @@ public class DefaultPackageSettings implements PackageSettings<PackageInfo> {
         return (version != null && version.contains("-"));
     }
 
+    @Override
+    public boolean isCustomized(PackageInfo packageInfo) {
+        // return false by default as no custom build options.
+        return false;
+    }
+
     private boolean isProjectDirectory(PackageInfo packageInfo) {
         File packageDir = packageInfo.getPackageFile();
         String version = packageInfo.getVersion();

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PackageSettings.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/util/PackageSettings.java
@@ -94,11 +94,19 @@ public interface PackageSettings<T> {
      * Determines if the package requires a build from source.
      * <p>
      * Even if the binary artifact of the package is available,
-     * the package may need a rebuild because of custom build
-     * options or environment.
+     * the package may need a rebuild because of editable current
+     * project or snapshots.
      *
      * @param t package information object
      * @return true when the package needs a rebuild from source
      */
     boolean requiresSourceBuild(T t);
+
+    /**
+     * Checks if the package is customized.
+     *
+     * @param t package information object
+     * @return true when the package is customized
+     */
+    boolean isCustomized(T t);
 }


### PR DESCRIPTION
The new API can be useful for checking if the binary artifact
of the package needs to rebuild if it doesn't exist in local
project cache.

Note that if the project is customized, it won't read and write
from global cache.