### PR TITLE
Adapt pip install task to invoke wheel building when not found.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/exception/MissingWheelCacheException.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/exception/MissingWheelCacheException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.exception;
+
+/**
+ * Failed to find wheel cache exception.
+ */
+public class MissingWheelCacheException extends RuntimeException {
+    public MissingWheelCacheException(String message) {
+        super(message);
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonInfrastructureDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonInfrastructureDefaultTask.java
@@ -16,6 +16,7 @@
 package com.linkedin.gradle.python.tasks;
 
 import com.linkedin.gradle.python.PythonExtension;
+import com.linkedin.gradle.python.exception.MissingWheelCacheException;
 import com.linkedin.gradle.python.exception.PipExecutionException;
 import com.linkedin.gradle.python.extension.PythonDetails;
 import com.linkedin.gradle.python.plugin.PythonHelpers;
@@ -197,10 +198,19 @@ abstract public class AbstractPythonInfrastructureDefaultTask extends DefaultTas
                 }
             } else {
                 try {
-                    pipInstallAction.execute(packageInfo, Collections.emptyList());
-                } catch (PipExecutionException e) {
-                    lastMessage = e.getPipText();
-                    throw e;
+                    // TODO: Switch allowBuildingFromSdist to false after wheel cache build and backing storage are done.
+                    pipInstallAction.execute(packageInfo, Collections.emptyList(), true);
+                } catch (MissingWheelCacheException e1) {
+                    try {
+                        // TODO: Make wheel from sdist, store to local cache and global cache if needed.
+                        pipInstallAction.execute(packageInfo, Collections.emptyList(), true);
+                    } catch (PipExecutionException e2) {
+                        lastMessage = e2.getPipText();
+                        throw e2;
+                    }
+                } catch (PipExecutionException e3) {
+                    lastMessage = e3.getPipText();
+                    throw e3;
                 }
             }
         });

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -141,7 +141,7 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
             progressLogger.progress("Preparing wheel $shortHand (${++counter} of $numberOfInstallables)")
 
             try {
-                wheelAction.execute(packageInfo, args)
+                wheelAction.execute(packageInfo, args, true)
             } catch (PipExecutionException e) {
                 lastInstallMessage = e.pipText
                 throw e

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -15,6 +15,8 @@
  */
 package com.linkedin.gradle.python.tasks
 
+
+import com.linkedin.gradle.python.exception.MissingWheelCacheException
 import com.linkedin.gradle.python.exception.PipExecutionException
 import com.linkedin.gradle.python.extension.PythonDetails
 import com.linkedin.gradle.python.plugin.PythonHelpers
@@ -140,10 +142,19 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider, Suppo
                 progressLogger.progress("Installing ${ shortHand } (${ ++counter } of ${ installableFiles.size() })")
 
                 try {
-                    pipInstallAction.execute(packageInfo, args)
-                } catch (PipExecutionException e) {
-                    lastInstallMessage = e.pipText
-                    throw e
+                    // TODO: Switch allowBuildingFromSdist to false after wheel cache build and backing storage are done.
+                    pipInstallAction.execute(packageInfo, args, true)
+                } catch (MissingWheelCacheException e1) {
+                    try {
+                        // TODO: Make wheel from sdist, store to local cache and global cache if needed.
+                        pipInstallAction.execute(packageInfo, args, true)
+                    } catch(PipExecutionException e2) {
+                        lastInstallMessage = e2.pipText
+                        throw e2
+                    }
+                } catch (PipExecutionException e3) {
+                    lastInstallMessage = e3.pipText
+                    throw e3
                 }
 
                 timer.stop()

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/AbstractPipAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/AbstractPipAction.java
@@ -65,7 +65,7 @@ abstract class AbstractPipAction {
         this.packageExcludeFilter = packageExcludeFilter;
     }
 
-    public void execute(PackageInfo packageInfo, List<String> extraArgs) {
+    public void execute(PackageInfo packageInfo, List<String> extraArgs, boolean allowBuildingFromSdist) {
         if (packageExcludeFilter != null && packageExcludeFilter.isSatisfiedBy(packageInfo)) {
             if (PythonHelpers.isPlainOrVerbose(project)) {
                 getLogger().lifecycle("Skipping {} - Excluded", packageInfo.toShortHand());
@@ -73,7 +73,7 @@ abstract class AbstractPipAction {
             return;
         }
 
-        doPipOperation(packageInfo, extraArgs);
+        doPipOperation(packageInfo, extraArgs, allowBuildingFromSdist);
     }
 
     void throwIfPythonVersionIsNotSupported(PackageInfo packageInfo) {
@@ -131,7 +131,7 @@ abstract class AbstractPipAction {
         }
     }
 
-    abstract void doPipOperation(PackageInfo packageInfo, List<String> extraArgs);
+    abstract void doPipOperation(PackageInfo packageInfo, List<String> extraArgs, boolean allowBuildingFromSdist);
 
     abstract Logger getLogger();
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelAction.java
@@ -68,7 +68,7 @@ public class PipWheelAction extends AbstractPipAction {
     }
 
     @Override
-    void doPipOperation(PackageInfo packageInfo, List<String> extraArgs) {
+    void doPipOperation(PackageInfo packageInfo, List<String> extraArgs, boolean allowBuildingFromSdist) {
         throwIfPythonVersionIsNotSupported(packageInfo);
 
         if (!packageSettings.requiresSourceBuild(packageInfo) && doesWheelExist(packageInfo)) {

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/tasks/action/pip/PipInstallActionTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/tasks/action/pip/PipInstallActionTest.groovy
@@ -47,7 +47,7 @@ class PipInstallActionTest extends Specification {
         def pipInstallAction = createPipInstallAction(settings, execSpec)
 
         when:
-        pipInstallAction.execute(packageInGradleCache("foo-1.0.0.tar.gz"), [])
+        pipInstallAction.execute(packageInGradleCache("foo-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.environment(['CPPFLAGS': '-I/some/custom/path/include', 'LDFLAGS': '-L/some/custom/path/lib -Wl,-rpath,/some/custom/path/lib'])
@@ -60,7 +60,7 @@ class PipInstallActionTest extends Specification {
         def pipInstallAction = createPipInstallAction(settings, execSpec)
 
         when:
-        pipInstallAction.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [])
+        pipInstallAction.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.commandLine(_) >> { List<List<String>> args ->
@@ -80,7 +80,7 @@ class PipInstallActionTest extends Specification {
         def pipInstallAction = createPipInstallAction(settings, execSpec)
 
         when:
-        pipInstallAction.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [])
+        pipInstallAction.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.commandLine(_) >> { List<List<String>> args ->
@@ -100,7 +100,7 @@ class PipInstallActionTest extends Specification {
         def pipInstallAction = createPipInstallAction(settings, execSpec)
 
         when:
-        pipInstallAction.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [])
+        pipInstallAction.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [], true)
 
         then:
         def e = thrown(PipExecutionException)
@@ -123,7 +123,7 @@ class PipInstallActionTest extends Specification {
         distInfo.createNewFile()
 
         when:
-        pipInstallAction.execute(packageInGradleCache("pyflakes-1.0.0.tar.gz"), [])
+        pipInstallAction.execute(packageInGradleCache("pyflakes-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.commandLine(_) >> { List<List<String>> args ->
@@ -148,7 +148,7 @@ class PipInstallActionTest extends Specification {
         eggFile.createNewFile()
 
         when:
-        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [])
+        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [], true)
 
         then:
         0 * execSpec._
@@ -164,7 +164,7 @@ class PipInstallActionTest extends Specification {
         eggFile.createNewFile()
 
         when:
-        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [])
+        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [], true)
 
         then:
         0 * execSpec._

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelActionTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelActionTest.groovy
@@ -48,7 +48,7 @@ class PipWheelActionTest extends Specification {
         def action = createPipWheelAction(settings, execSpec)
 
         when:
-        action.execute(packageInGradleCache("foo-1.0.0.tar.gz"), [])
+        action.execute(packageInGradleCache("foo-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.environment(['CPPFLAGS': '-I/some/custom/path/include', 'LDFLAGS': '-L/some/custom/path/lib -Wl,-rpath,/some/custom/path/lib'])
@@ -61,7 +61,7 @@ class PipWheelActionTest extends Specification {
         def action = createPipWheelAction(settings, execSpec)
 
         when:
-        action.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [])
+        action.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.commandLine(_) >> { List<List<String>> args ->
@@ -81,7 +81,7 @@ class PipWheelActionTest extends Specification {
         def action = createPipWheelAction(settings, execSpec)
 
         when:
-        action.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [])
+        action.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.commandLine(_) >> { List<List<String>> args ->
@@ -101,7 +101,7 @@ class PipWheelActionTest extends Specification {
         def action = createPipWheelAction(settings, execSpec)
 
         when:
-        action.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [])
+        action.execute(packageInGradleCache("setuptools-1.0.0.tar.gz"), [], true)
 
         then:
         def e = thrown(PipExecutionException)
@@ -119,7 +119,7 @@ class PipWheelActionTest extends Specification {
         new File(wheelCache, "pyflakes-1.6.0-py2.py3-none-any.whl").createNewFile()
 
         when:
-        action.execute(packageInGradleCache("pyflakes-1.0.0.tar.gz"), [])
+        action.execute(packageInGradleCache("pyflakes-1.0.0.tar.gz"), [], true)
 
         then:
         1 * execSpec.commandLine(_) >> { List<List<String>> args ->
@@ -142,7 +142,7 @@ class PipWheelActionTest extends Specification {
         new File(wheelCache, "pyflakes-1.6.0-py2.py3-none-any.whl").createNewFile()
 
         when:
-        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [])
+        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [], true)
 
         then:
         0 * execSpec._
@@ -159,7 +159,7 @@ class PipWheelActionTest extends Specification {
         assert !new File(temporaryFolder.root, "build/wheel-cache/pyflakes-1.6.0-py2.py3-none-any.whl").exists()
 
         when:
-        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [])
+        action.execute(packageInGradleCache("pyflakes-1.6.0.tar.gz"), [], true)
 
         then:
         0 * execSpec._


### PR DESCRIPTION
Add an extra allowBuildingFromSdist parameter in AbstractPipAction
execute function. It allows PipInstallTask to pass
allowBuildingFromSdist to PipInstallAction so that it can try to
install from wheel, and then fall back to install from sdist to
keep current behavior.