### PR TITLE
Add a no-op `buildPex` task for backward compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
             - image: openjdk:8-jdk
         environment:
             JVM_OPTS: -Xmx2048m
-            GRADLE_OPTS: -Dorg.gradle.daemon=false
+            GRADLE_OPTS: -Xmx2048m
         steps:
             - run:
                 name: Prepare System

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
             - image: openjdk:8-jdk
         environment:
             JVM_OPTS: -Xmx2048m
+            GRADLE_OPTS: -Dorg.gradle.daemon=false
         steps:
             - run:
                 name: Prepare System
@@ -27,7 +28,7 @@ jobs:
                     - ~/.gradle
             - run:
                 name: Run Build
-                command: ./gradlew build --console plain --max-workers=2 --info
+                command: ./gradlew build --console plain --max-workers=2
 
             - run:
                 name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
                     - ~/.gradle
             - run:
                 name: Run Build
-                command: ./gradlew build --console plain --max-workers=2
+                command: ./gradlew build --console plain --max-workers=2 --info
 
             - run:
                 name: Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             JVM_OPTS: -Xmx2048m
         steps:
             - run:
-                name: Prepair System
+                name: Prepare System
                 command: |
                     apt-get update && apt-get -y upgrade
                     apt-get install -y python2.7 python3.5

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PexExtension.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/PexExtension.java
@@ -27,7 +27,16 @@ import java.io.File;
 
 
 public class PexExtension implements ApplicationContainer {
-    public static final String TASK_BUILD_PEX = "buildPex";
+    // 2019-04-01(warsaw): For backward compatibility, we must expose a no-op
+    // buildPex task unconditionally.  This will be created in
+    // PythonContainerPlugin and tied into the task hierarchy in the right
+    // place.  realBuildPex task is the actual pex building task, but these
+    // are only needed if pexes are selected (and won't get created until
+    // after build.gradle evaluation).
+    //
+    // Yes, this is gross and we should deprecate this mess at our earliest convenience.
+    public static final String TASK_BUILD_PEX = "realBuildPex";
+    public static final String TASK_BUILD_NOOP_PEX = "buildPex";
 
     private File cache;
     // Default to fat zipapps on Windows, since our wrappers are fairly POSIX specific.

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonContainerPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonContainerPlugin.java
@@ -17,7 +17,9 @@ package com.linkedin.gradle.python.plugin;
 
 import com.linkedin.gradle.python.PythonExtension;
 import com.linkedin.gradle.python.extension.DeployableExtension;
+import com.linkedin.gradle.python.extension.PexExtension;
 import com.linkedin.gradle.python.tasks.BuildWheelsTask;
+import com.linkedin.gradle.python.tasks.NoopBuildPexTask;
 import com.linkedin.gradle.python.tasks.PythonContainerTask;
 import com.linkedin.gradle.python.util.ApplicationContainer;
 import com.linkedin.gradle.python.util.ExtensionUtils;
@@ -67,6 +69,10 @@ public class PythonContainerPlugin extends PythonBasePlugin {
              * generic Python builds.  E.g. we make the pex task depend on it.
              */
             Task assemble = tasks.create(ApplicationContainer.TASK_ASSEMBLE_CONTAINERS);
+
+            // Add this no-op task for backward compatibility.  See PexExtension for details.
+            Task noop = tasks.create(PexExtension.TASK_BUILD_NOOP_PEX, NoopBuildPexTask.class);
+            assemble.dependsOn(noop);
 
             Tar tar = tasks.create(ApplicationContainer.TASK_PACKAGE_DEPLOYABLE, Tar.class);
             tar.setCompression(Compression.GZIP);

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/NoopBuildPexTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/NoopBuildPexTask.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+
+public class NoopBuildPexTask extends DefaultTask implements PythonContainerTask {
+    private static final Logger LOG = Logging.getLogger(NoopBuildPexTask.class);
+    private static final String DISABLED_MESSAGE =
+          "######################### WARNING ##########################\n"
+        + "The buildPex task has been deprecated.\n"
+        + "Please use the assemblerContainers task instead.\n"
+        + "############################################################";
+
+    public Task dependsOn(Object... paths) {
+        LOG.warn(DISABLED_MESSAGE);
+        return super.dependsOn(paths);
+    }
+}


### PR DESCRIPTION
* Make the assembleContainers task depend on the buildPex task
* Print a warning when `buildTask` dependsOn() is called
* Name the real build pex task `realBuildPex`