### PR TITLE
Add task action method to no-op task.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ jobs:
         docker:
             - image: openjdk:8-jdk
         environment:
-            JVM_OPTS: -Xmx2048m
-            GRADLE_OPTS: -Xmx2048m
+            _JAVA_OPTIONS: "-Xmx1024m -Xms256m"
         steps:
             - run:
                 name: Prepare System
@@ -44,8 +43,6 @@ jobs:
     deploy:
         docker:
             - image: openjdk:8-jdk
-        environment:
-            JVM_OPTS: -Xmx2048m
         steps:
             - checkout
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PyGradle
 
 [![CircleCI](https://img.shields.io/circleci/project/github/linkedin/pygradle.svg?style=flat-square)](https://circleci.com/gh/linkedin/pygradle)
+[![Travis](https://img.shields.io/travis/linkedin/pygradle.svg?style=flat-square)](https://travis-ci.org/linkedin/pygradle)
 [![AppVeyor](https://img.shields.io/appveyor/ci/ethankhall/pygradle.svg?style=flat-square)](https://ci.appveyor.com/project/ethankhall/pygradle)
 [![Bintray](https://img.shields.io/bintray/v/linkedin/maven/pygradle-plugin.svg?style=flat-square)](https://bintray.com/linkedin/maven/pygradle-plugin)
 [![Linkedin](https://img.shields.io/badge/opensource-linkedin-blue.svg?style=flat-square)](https://engineering.linkedin.com/)

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/NoopBuildPexTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/NoopBuildPexTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
 
 
 public class NoopBuildPexTask extends DefaultTask implements PythonContainerTask {
@@ -28,6 +29,9 @@ public class NoopBuildPexTask extends DefaultTask implements PythonContainerTask
         + "The buildPex task has been deprecated.\n"
         + "Please use the assemblerContainers task instead.\n"
         + "############################################################";
+
+    @TaskAction
+    public void noOp() { }
 
     public Task dependsOn(Object... paths) {
         LOG.warn(DISABLED_MESSAGE);


### PR DESCRIPTION
Also, make sure to check the task is not already created before
attempting to create it.

Add Travis badge to README.

Remove ineffective JVM_OPTS (Clojure specific) and GRADLE_OPTS (used for
client VM that handles command line input/output only, not the actual
build). Use _JAVA_OPTIONS instead.