### PR TITLE
Fix typo in warning and add a suppression boolean

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonContainerPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonContainerPlugin.java
@@ -104,9 +104,16 @@ public class PythonContainerPlugin extends PythonBasePlugin {
              * assemble task depends on all the implementers of
              * PythonContainerTask, and the deployable task depends on the
              * assemble task.
+             *
+             * While we're doing this though, suppress the deprecation warning
+             * normally thrown in NoopBuildPexTask when user code calls its
+             * .dependsOn().
              */
             postContainer.addDependencies(project);
             postContainer.makeTasks(project);
+
+            NoopBuildPexTask noopTask = (NoopBuildPexTask) tasks.findByName(PexExtension.TASK_BUILD_NOOP_PEX);
+            noopTask.suppressWarning = true;
 
             Task assemble = tasks.getByName(ApplicationContainer.TASK_ASSEMBLE_CONTAINERS);
             Task parent = tasks.getByName(ApplicationContainer.TASK_BUILD_PROJECT_WHEEL);
@@ -115,6 +122,9 @@ public class PythonContainerPlugin extends PythonBasePlugin {
                 assemble.dependsOn(task);
                 task.dependsOn(parent);
             }
+
+            // Turn the warning back on.
+            noopTask.suppressWarning = false;
         });
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/NoopBuildPexTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/NoopBuildPexTask.java
@@ -27,14 +27,20 @@ public class NoopBuildPexTask extends DefaultTask implements PythonContainerTask
     private static final String DISABLED_MESSAGE =
           "######################### WARNING ##########################\n"
         + "The buildPex task has been deprecated.\n"
-        + "Please use the assemblerContainers task instead.\n"
+        + "Please use the assembleContainers task instead.\n"
         + "############################################################";
+
+    // This is used to suppress the warning when PythonContainerPlugin plumbs
+    // this task into the task hierarchy, which isn't user code.
+    public boolean suppressWarning = false;
 
     @TaskAction
     public void noOp() { }
 
     public Task dependsOn(Object... paths) {
-        LOG.warn(DISABLED_MESSAGE);
+        if (!suppressWarning) {
+            LOG.warn(DISABLED_MESSAGE);
+        }
         return super.dependsOn(paths);
     }
 }


### PR DESCRIPTION
We don't want bogus warnings when the PythonContainerPlugin itself is calling
NoopBuildPexTask.dependsOn().