### PR TITLE
Adapt build wheels task and action to layered cache.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -34,6 +34,7 @@ import com.linkedin.gradle.python.util.PackageInfo
 import com.linkedin.gradle.python.util.PackageSettings
 import com.linkedin.gradle.python.util.internal.TaskTimer
 import com.linkedin.gradle.python.wheel.EmptyWheelCache
+import com.linkedin.gradle.python.wheel.LayeredWheelCache
 import com.linkedin.gradle.python.wheel.WheelCache
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -79,7 +80,10 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
 
     @TaskAction
     void buildWheelsTask() {
-        buildWheels(project, DependencyOrder.getConfigurationFiles(installFileCollection), getPythonDetails())
+        // With LayeredWheelCache, heels are already built where this task would put them.
+        if (!(wheelCache instanceof LayeredWheelCache)) {
+            buildWheels(project, DependencyOrder.getConfigurationFiles(installFileCollection), getPythonDetails())
+        }
     }
 
     /**
@@ -117,7 +121,7 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
      */
     private void buildWheels(Project project, Collection<File> installables, PythonDetails pythonDetails) {
 
-        ProgressLoggerFactory progressLoggerFactory = getServices().get(ProgressLoggerFactory)
+        ProgressLoggerFactory progressLoggerFactory = (ProgressLoggerFactory) getServices().get(ProgressLoggerFactory)
         ProgressLogger progressLogger = progressLoggerFactory.newOperation(BuildWheelsTask)
         progressLogger.setDescription("Building Wheels")
         progressLogger.started()

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelAction.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/PipWheelAction.java
@@ -108,11 +108,14 @@ public class PipWheelAction extends AbstractPipAction {
             Optional<File> wheel = wheelCache.findWheel(packageInfo.getName(), packageInfo.getVersion(), pythonDetails);
             if (wheel.isPresent()) {
                 File wheelFile = wheel.get();
+                File wheelCopy = new File(wheelExtension.getWheelCache(), wheelFile.getName());
 
-                try {
-                    FileUtils.copyFile(wheelFile, new File(wheelExtension.getWheelCache(), wheelFile.getName()));
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
+                if (!wheelFile.equals(wheelCopy)) {
+                    try {
+                        FileUtils.copyFile(wheelFile, wheelCopy);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
                 }
 
                 if (PythonHelpers.isPlainOrVerbose(project)) {


### PR DESCRIPTION
The action should not attempt to copy wheels over themselves.
The task is a no-op when layered cache is used.