### PR TITLE
Add plugin for the layered wheel cache.

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/FailureReasonProviderIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/FailureReasonProviderIntegrationTest.groovy
@@ -79,6 +79,16 @@ class FailureReasonProviderIntegrationTest extends Specification {
         | project.gradle.addListener(new MyTaskListener())
         |
         | version = '1.0.0'
+        |
+        | // allow it to build wheels by disabling layered wheel cache
+        | import com.linkedin.gradle.python.tasks.supports.SupportsWheelCache
+        | import com.linkedin.gradle.python.wheel.EmptyWheelCache
+        | afterEvaluate {
+        |     def wheelCache = new EmptyWheelCache()
+        |     tasks.withType(SupportsWheelCache) { SupportsWheelCache task ->
+        |         task.wheelCache = wheelCache
+        |     }
+        | }
         | ${ PyGradleTestBuilder.createRepoClosure() }
         """.stripMargin().stripIndent()
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/WheelExtension.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/WheelExtension.java
@@ -15,14 +15,21 @@
  */
 package com.linkedin.gradle.python.extension;
 
+import com.linkedin.gradle.python.wheel.WheelCacheLayer;
 import org.gradle.api.Project;
 
 import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 
 
 public class WheelExtension {
 
     private File wheelCache;
+    private File hostLayerWheelCache;
+    private File projectLayerWheelCache;
+    private Map<WheelCacheLayer, File> layeredCacheMap = new LinkedHashMap<>();
 
     public WheelExtension(Project project) {
         wheelCache = new File(project.getBuildDir(), "wheel-cache");
@@ -34,5 +41,27 @@ public class WheelExtension {
 
     public void setWheelCache(File wheelCache) {
         this.wheelCache = wheelCache;
+    }
+
+    public Optional<File> getHostLayerWheelCache() {
+        return Optional.ofNullable(hostLayerWheelCache);
+    }
+
+    public void setHostLayerWheelCache(File hostLayerWheelCache) {
+        this.hostLayerWheelCache = hostLayerWheelCache;
+        layeredCacheMap.put(WheelCacheLayer.HOST_LAYER, this.hostLayerWheelCache);
+    }
+
+    public Optional<File> getProjectLayerWheelCache() {
+        return Optional.ofNullable(projectLayerWheelCache);
+    }
+
+    public void setProjectLayerWheelCache(File projectLayerWheelCache) {
+        this.projectLayerWheelCache = projectLayerWheelCache;
+        layeredCacheMap.put(WheelCacheLayer.PROJECT_LAYER, this.projectLayerWheelCache);
+    }
+
+    public Map<WheelCacheLayer, File> getLayeredCacheMap() {
+        return layeredCacheMap;
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/LayeredWheelCachePlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/LayeredWheelCachePlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.plugin;
+
+import com.linkedin.gradle.python.extension.WheelExtension;
+import com.linkedin.gradle.python.tasks.LayeredWheelCacheTask;
+import com.linkedin.gradle.python.tasks.provides.ProvidesVenv;
+import com.linkedin.gradle.python.tasks.supports.SupportsWheelCache;
+import com.linkedin.gradle.python.util.ExtensionUtils;
+import com.linkedin.gradle.python.wheel.EditablePythonAbiContainer;
+import com.linkedin.gradle.python.wheel.LayeredWheelCache;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskContainer;
+
+import static com.linkedin.gradle.python.util.StandardTextValues.TASK_FLAKE;
+import static com.linkedin.gradle.python.util.StandardTextValues.TASK_VENV_CREATE;
+
+
+/**
+ * The plugin provides layered wheel cache to builds.
+ */
+public class LayeredWheelCachePlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        WheelExtension wheelExtension = ExtensionUtils.maybeCreateWheelExtension(project);
+        EditablePythonAbiContainer supportedWheelFormats = ExtensionUtils.getEditablePythonAbiContainer(project);
+        LayeredWheelCache wheelCache = new LayeredWheelCache(wheelExtension.getLayeredCacheMap(), supportedWheelFormats);
+
+        TaskContainer tasks = project.getTasks();
+
+        tasks.withType(ProvidesVenv.class, task -> task.setEditablePythonAbiContainer(supportedWheelFormats));
+
+        tasks.withType(SupportsWheelCache.class, task -> task.setWheelCache(wheelCache));
+
+        tasks.create(LayeredWheelCacheTask.TASK_LAYERED_WHEEL_CACHE, LayeredWheelCacheTask.class, task -> {
+            tasks.getByName(TASK_VENV_CREATE.getValue()).dependsOn(task);
+            tasks.getByName(TASK_FLAKE.getValue()).dependsOn(task);
+        });
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.java
@@ -130,6 +130,9 @@ public class PythonPlugin implements Plugin<Project> {
         project.getPlugins().apply(InstallDependenciesPlugin.class);
         project.getPlugins().apply(ValidationPlugin.class);
         project.getPlugins().apply(DocumentationPlugin.class);
+
+        project.getPlugins().apply(LayeredWheelCachePlugin.class);
+
         PyPiRepoUtil.setupPyGradleRepo(project);
     }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/LayeredWheelCacheTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/LayeredWheelCacheTask.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 LinkedIn Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.gradle.python.tasks;
+
+import com.linkedin.gradle.python.extension.WheelExtension;
+import com.linkedin.gradle.python.util.ExtensionUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.util.Optional;
+
+
+public class LayeredWheelCacheTask extends DefaultTask {
+    public static final String TASK_LAYERED_WHEEL_CACHE = "layeredWheelCacheTask";
+
+    @TaskAction
+    public void makeCacheDirectories() {
+        /*
+         * We do not need to do:
+         *     getProject().mkdir(getHostLayerWheelCache());
+         *     getProject().mkdir(getProjectLayerWheelCache());
+         * because the @OutputDirectory annotation on the getters below
+         * ensures they get created.
+         */
+    }
+
+    @OutputDirectory
+    public File getHostLayerWheelCache() {
+        WheelExtension wheelExtension = ExtensionUtils.getPythonComponentExtension(getProject(), WheelExtension.class);
+        Optional<File> cacheDir =  wheelExtension.getHostLayerWheelCache();
+        if (!cacheDir.isPresent()) {
+            cacheDir = Optional.of(new File(getProject().getGradle().getGradleUserHomeDir(), "pygradle/wheel-cache"));
+            wheelExtension.setHostLayerWheelCache(cacheDir.get());
+        }
+        return cacheDir.get();
+    }
+
+    @OutputDirectory
+    public File getProjectLayerWheelCache() {
+        WheelExtension wheelExtension = ExtensionUtils.getPythonComponentExtension(getProject(), WheelExtension.class);
+        Optional<File> cacheDir =  wheelExtension.getProjectLayerWheelCache();
+        if (!cacheDir.isPresent()) {
+            cacheDir = Optional.of(new File(getProject().getBuildDir(), "wheel-cache"));
+            wheelExtension.setProjectLayerWheelCache(cacheDir.get());
+        }
+        return cacheDir.get();
+    }
+}

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/LayeredWheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/LayeredWheelCache.java
@@ -44,7 +44,6 @@ public class LayeredWheelCache implements WheelCache, Serializable {
 
     @Override
     public Optional<File> findWheel(String name, String version, PythonDetails pythonDetails) {
-        // TODO: Make sure layeredCacheMap is a LinkedHashMap when we initialize it in the plugin.
         for (WheelCacheLayer wheelCacheLayer : layeredCacheMap.keySet()) {
             Optional<File> wheel = findWheel(name, version, pythonDetails.getVirtualEnvInterpreter(), wheelCacheLayer);
 
@@ -85,7 +84,7 @@ public class LayeredWheelCache implements WheelCache, Serializable {
 
     @Override
     public Optional<File> getTargetDirectory() {
-        return Optional.of(layeredCacheMap.get(WheelCacheLayer.PROJECT_LAYER));
+        return Optional.ofNullable(layeredCacheMap.get(WheelCacheLayer.PROJECT_LAYER));
     }
 
     /**

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.9.25
+version=0.10.0


### PR DESCRIPTION
The plugin creates and orders a simple task, and sets layered wheel
cache and ABI container on tasks that support them.
The output directory methods on the task ensure that cache layers are
set up correctly if not initialized and that directories get created.

Bump the minor version.