### PR TITLE
Fix the handling of generated code and store overwrite.

### DIFF
--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/LayeredWheelCacheTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/wheel/LayeredWheelCacheTest.groovy
@@ -155,4 +155,18 @@ class LayeredWheelCacheTest extends Specification {
         cache.findWheel('Sphinx', '1.6.3', pythonDetails, WheelCacheLayer.HOST_LAYER).isPresent()
     }
 
+    def "stores over already present wheel"() {
+        setup: "put the wheel in both caches"
+        def wheelFile  = new File(otherCache, 'Sphinx-1.6.3-py2.py3-none-any.whl')
+        wheelFile.createNewFile()
+        cache.storeWheel(wheelFile)
+        def wheelInHostLayer = cache.findWheel('Sphinx', '1.6.3', pythonDetails, WheelCacheLayer.HOST_LAYER).get()
+
+        when: "wheel is stored from host to project layer without raising an exception"
+        cache.storeWheel(wheelInHostLayer, WheelCacheLayer.PROJECT_LAYER)
+
+        then: "wheel is found in both layers"
+        cache.findWheel('Sphinx', '1.6.3', pythonDetails, WheelCacheLayer.PROJECT_LAYER).isPresent()
+        cache.findWheel('Sphinx', '1.6.3', pythonDetails, WheelCacheLayer.HOST_LAYER).isPresent()
+    }
 }


### PR DESCRIPTION
A generated code, such as rest.li, is also being installed from a
directory, not an sdist package. We need to handle the package version
number similar to the project directory.

Two sub-projects building at the same time can cause the behavior where
both of them do not find a wheel in any layer and proceed to build
it in their project layers. Then one of them stores it into the host
layer before another. The second one should not fail if that wheel is
present when it tries to store it in the host layer.

Added tests for both cases and a safety belt against null.