### PR TITLE
Make wheel cache storing much more robust.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -80,8 +80,8 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
 
     @TaskAction
     void buildWheelsTask() {
-        // With LayeredWheelCache, heels are already built where this task would put them.
-        if (!(wheelCache instanceof LayeredWheelCache)) {
+        // With LayeredWheelCache, wheels are almost always already built where this task would put them.
+        if (!wheelCache.isWheelsReady()) {
             buildWheels(project, DependencyOrder.getConfigurationFiles(installFileCollection), getPythonDetails())
         }
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/WheelBuilder.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/action/pip/WheelBuilder.java
@@ -60,7 +60,7 @@ public class WheelBuilder extends AbstractPipAction {
 
     // Environment variables used for a specific package only and customizing its build.
     private static final Map<String, List<String>> CUSTOM_ENVIRONMENT = Collections.unmodifiableMap(Stream.of(
-        new AbstractMap.SimpleEntry<>("numpy", Arrays.asList("BLAS", "OPENBLAS", "ATLAS")),
+        new AbstractMap.SimpleEntry<>("numpy", Arrays.asList("ATLAS", "BLAS", "LAPACK", "OPENBLAS")),
         new AbstractMap.SimpleEntry<>("pycurl", Collections.singletonList("PYCURL_SSL_LIBRARY"))
     ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
 
@@ -219,9 +219,13 @@ public class WheelBuilder extends AbstractPipAction {
                  * Then retry.
                  */
                 customBuild = true;
-                execute(packageInfo, extraArgs);
+                try {
+                    execute(packageInfo, extraArgs);
+                } catch (PipExecutionException ignored) {
+                    wheelCache.setWheelsReady(false);
+                }
             } else {
-                throw e;
+                wheelCache.setWheelsReady(false);
             }
         }
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/EmptyWheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/EmptyWheelCache.java
@@ -41,4 +41,12 @@ public class EmptyWheelCache implements WheelCache {
     public Optional<File> getTargetDirectory() {
         return Optional.empty();
     }
+
+    @Override
+    public boolean isWheelsReady() {
+        return false;
+    }
+
+    @Override
+    public void setWheelsReady(boolean wheelsReady) { }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/FileBackedWheelCache.java
@@ -60,6 +60,14 @@ public class FileBackedWheelCache implements WheelCache, Serializable {
         return Optional.empty();
     }
 
+    @Override
+    public boolean isWheelsReady() {
+        return false;
+    }
+
+    @Override
+    public void setWheelsReady(boolean wheelsReady) { }
+
     /**
      * Finds a wheel in the cache.
      *

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/WheelCache.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/wheel/WheelCache.java
@@ -68,4 +68,21 @@ public interface WheelCache extends Serializable {
      * @return the directory used for wheel build target
      */
     Optional<File> getTargetDirectory();
+
+    /**
+     * Tells if all wheels are ready for packing into a container.
+     *
+     * <p>If they are, we do not need to run a legacy build wheels task.
+     * Otherwise, at least some still need building.</p>
+     *
+     * @return true when all wheels were built into the project layer cache
+     */
+    boolean isWheelsReady();
+
+    /**
+     * Sets the flag whether the wheels are ready for packing into a container.
+     *
+     * @param wheelsReady indicator of wheel readiness for packing.
+     */
+    void setWheelsReady(boolean wheelsReady);
 }


### PR DESCRIPTION
Besides gracefully accepting already present wheel, we need to accept
absence of the wheel or cache directory. Nothing bad will happen if we
do not store the wheel from one layer into another. On the other hand,
we found out that rogue Gradle tasks can "pull the rug under us" by
triggering cleanup tasks and removing project layer cache directory.
This change provides for graceful handling of these exceptions and
recovery from them.

Similarly, we now do not fail when wheel building does not succeed.
Again, in testing we found the libraries that do not build the wheel
for the current project, but don't need it because they publish only an
sdist package. So, we now gracefully accept fail wheel build, raise the
flag that some wheels are not completed and let pip install from
sdist/editable. The flag allows build wheels task to try rebuilding
missing wheels one more time as it used to do which happens only for
container builds.

One small change was also added to the numpy environment to account for
LAPACK setting as custom.