### PR TITLE
Treat project wheel as a special case.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -34,7 +34,6 @@ import com.linkedin.gradle.python.util.PackageInfo
 import com.linkedin.gradle.python.util.PackageSettings
 import com.linkedin.gradle.python.util.internal.TaskTimer
 import com.linkedin.gradle.python.wheel.EmptyWheelCache
-import com.linkedin.gradle.python.wheel.LayeredWheelCache
 import com.linkedin.gradle.python.wheel.WheelCache
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -80,8 +79,12 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
 
     @TaskAction
     void buildWheelsTask() {
-        // With LayeredWheelCache, wheels are almost always already built where this task would put them.
-        if (!wheelCache.isWheelsReady()) {
+        /*
+         * With LayeredWheelCache, wheels are almost always already built where this task would put them.
+         * Project wheel is an exception.
+         */
+        boolean isProject = installFileCollection.size() == 1 && installFileCollection.contains(project.getProjectDir())
+        if (isProject || !wheelCache.isWheelsReady()) {
             buildWheels(project, DependencyOrder.getConfigurationFiles(installFileCollection), getPythonDetails())
         }
     }

--- a/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/tasks/action/pip/WheelBuilderTest.groovy
+++ b/pygradle-plugin/src/test/groovy/com/linkedin/gradle/python/tasks/action/pip/WheelBuilderTest.groovy
@@ -359,32 +359,20 @@ class WheelBuilderTest extends Specification {
         }
     }
 
-    def 'builds project wheel but returns the project itself'() {
+    def 'does not build project wheel but returns the project itself'() {
         setup: "do not return wheel from cache layers on first attempt"
         def execSpec = Mock(ExecSpec)
-        def fakeWheel = 'fake/project-dir/wheel'
-        // Cardinality of calls on stubs cannot be asserted, as opposed to mocks, so we keep the counter.
-        def storeCounter = 0
         def stubWheelCache = Stub(WheelCache) {
             getTargetDirectory() >> Optional.of(new File('fake/project-dir'))
-            findWheel(!null, !null, !null, WheelCacheLayer.PROJECT_LAYER) >>> [
-                Optional.empty(), Optional.of(new File(fakeWheel))]
-            findWheel(!null, !null, !null, WheelCacheLayer.HOST_LAYER) >> Optional.empty()
-            storeWheel(!null, WheelCacheLayer.HOST_LAYER) >> { storeCounter++ }
         }
         def wheelBuilder = createWheelBuilder(execSpec, stubWheelCache)
 
         when: "we request project to be built"
         def pkg = wheelBuilder.getPackage(PackageInfo.fromPath(wheelBuilder.project.getProjectDir()), [])
 
-        then: "wheel is built but not stored to host layer and project directory returned for editable install"
+        then: "wheel is not built and project directory is returned for editable install"
         pkg.toString() == wheelBuilder.project.getProjectDir().toString()
-        storeCounter == 0
-        1 * execSpec.commandLine(_) >> { List<List<String>> args ->
-            println args
-            def it = args[0]
-            assert it[2] == 'wheel'
-        }
+        0 * execSpec._
     }
 
     def 'builds generated code wheel but getting the project version for it'() {


### PR DESCRIPTION
The project wheel will be built after the editable install for
development. This ensures that the file manifest is generated for the
project package before the wheel is built. Otherwise, wheel does not
include resource files that `include_package_data=True` ensures to be
packed into an sdist.

This also helps some packages that generate code after the development
install and expect that code to be packed into the wheel.