### PR TITLE
Switch to openjdk for Travis checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Travis started switching to Ubuntu 16.04 (Xenial) from 14.04 (Trusty)
for all builds. The Oracle JDK does not come pre-installed any more and
is causing the issue during install:
```
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace
"/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
install-jdk.sh 2019-05-02
Expected feature release number in range of 9 to 13, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8"
--workspace "/home/travis/.cache/install-jdk" --feature "8" --license
"BCL"" failed and exited with 3 during .
Your build has been stopped.
```
One option is to set `dist: trusty` but that's an EOL distro at this
point. Switching to openjdk feels safer choice at this point.

References:

* https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
* https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038