### PR TITLE
Refactor MypyTask and MypyExtension for local customizations

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
@@ -15,18 +15,10 @@
  */
 package com.linkedin.gradle.python.extension;
 
-import org.gradle.api.Project;
-import com.linkedin.gradle.python.util.ExtensionUtils;
-
 
 public class MypyExtension {
     private boolean run;
     private String[] arguments = null;
-    private String srcDir;
-
-    public MypyExtension(Project project) {
-        srcDir = ExtensionUtils.getPythonExtension(project).srcDir;
-    }
 
     public boolean isRun() {
         return run;
@@ -41,9 +33,6 @@ public class MypyExtension {
     }
 
     public String[] getArguments() {
-        if (arguments == null) {
-            return new String[]{srcDir};
-        }
         return arguments;
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/extension/MypyExtension.java
@@ -15,8 +15,18 @@
  */
 package com.linkedin.gradle.python.extension;
 
+import org.gradle.api.Project;
+import com.linkedin.gradle.python.util.ExtensionUtils;
+
+
 public class MypyExtension {
     private boolean run;
+    private String[] arguments = null;
+    private String srcDir;
+
+    public MypyExtension(Project project) {
+        srcDir = ExtensionUtils.getPythonExtension(project).srcDir;
+    }
 
     public boolean isRun() {
         return run;
@@ -24,5 +34,16 @@ public class MypyExtension {
 
     public void setRun(boolean run) {
         this.run = run;
+    }
+
+    public void setArguments(String argumentString) {
+        arguments = argumentString.split("\\s+");
+    }
+
+    public String[] getArguments() {
+        if (arguments == null) {
+            return new String[]{srcDir};
+        }
+        return arguments;
     }
 }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
@@ -101,7 +101,7 @@ public class ValidationPlugin implements Plugin<Project> {
          *
          * This uses the mypy.ini file if present to configure mypy.
          */
-        MypyExtension mypy = ExtensionUtils.maybeCreate(project, "mypy", MypyExtension.class);
+        MypyExtension mypy = ExtensionUtils.maybeCreate(project, "mypy", MypyExtension.class, project);
         project.getTasks().create(TASK_MYPY.getValue(), MypyTask.class,
             task -> task.onlyIf(it -> project.file(settings.srcDir).exists() && mypy.isRun()));
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/internal/ValidationPlugin.java
@@ -101,7 +101,7 @@ public class ValidationPlugin implements Plugin<Project> {
          *
          * This uses the mypy.ini file if present to configure mypy.
          */
-        MypyExtension mypy = ExtensionUtils.maybeCreate(project, "mypy", MypyExtension.class, project);
+        MypyExtension mypy = ExtensionUtils.maybeCreate(project, "mypy", MypyExtension.class);
         project.getTasks().create(TASK_MYPY.getValue(), MypyTask.class,
             task -> task.onlyIf(it -> project.file(settings.srcDir).exists() && mypy.isRun()));
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/MypyTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/MypyTask.java
@@ -15,7 +15,10 @@
  */
 package com.linkedin.gradle.python.tasks;
 
+import com.linkedin.gradle.python.extension.MypyExtension;
 import com.linkedin.gradle.python.extension.PythonDetails;
+import com.linkedin.gradle.python.util.ExtensionUtils;
+import org.gradle.api.Project;
 import org.gradle.process.ExecResult;
 
 
@@ -24,7 +27,10 @@ public class MypyTask extends AbstractPythonMainSourceDefaultTask {
     public void preExecution() {
         PythonDetails mypyDetails = getPythonDetails();
         args(mypyDetails.getVirtualEnvironment().findExecutable("mypy").getAbsolutePath());
-        args(getPythonExtension().srcDir);
+
+        Project project = getProject();
+        MypyExtension mypy = ExtensionUtils.maybeCreate(project, "mypy", MypyExtension.class, project);
+        args(mypy.getArguments());
     }
 
     public void processResults(ExecResult results) {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/MypyTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/MypyTask.java
@@ -29,8 +29,13 @@ public class MypyTask extends AbstractPythonMainSourceDefaultTask {
         args(mypyDetails.getVirtualEnvironment().findExecutable("mypy").getAbsolutePath());
 
         Project project = getProject();
-        MypyExtension mypy = ExtensionUtils.maybeCreate(project, "mypy", MypyExtension.class, project);
-        args(mypy.getArguments());
+        MypyExtension mypy = ExtensionUtils.getPythonComponentExtension(project, MypyExtension.class);
+
+        String[] arguments = mypy.getArguments();
+        if (arguments == null) {
+            arguments = new String[]{getPythonExtension().srcDir};
+        }
+        args(arguments);
     }
 
     public void processResults(ExecResult results) {


### PR DESCRIPTION
If and when https://github.com/python/mypy/pull/7219 lands, we will have the
ability to tell mypy to traverse into PEP 420 namespace packages.  In order to
preserve backward compatibility, the MypyExtension now allows clients to set
the mypy command line arguments, but if they don't it will use the old command
line of just passing the source directory.