### PR TITLE
Modified ValidationPlugin to ensure pytests only run once

### DIFF
--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PexIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PexIntegrationTest.groovy
@@ -71,6 +71,7 @@ class PexIntegrationTest extends Specification {
         result.task(':foo:installTestRequirements').outcome == TaskOutcome.SUCCESS
         result.task(':foo:createVirtualEnvironment').outcome == TaskOutcome.SUCCESS
         result.task(':foo:installProject').outcome == TaskOutcome.SUCCESS
+        result.task(':foo:coverage').outcome == TaskOutcome.SKIPPED
         result.task(':foo:pytest').outcome == TaskOutcome.SUCCESS
         result.task(':foo:check').outcome == TaskOutcome.SUCCESS
         result.task(':foo:build').outcome == TaskOutcome.SUCCESS

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/PythonPluginIntegrationTest.groovy
@@ -65,8 +65,8 @@ class PythonPluginIntegrationTest extends Specification {
         result.task(':foo:pytest').outcome == TaskOutcome.SUCCESS
         result.task(':foo:check').outcome == TaskOutcome.SUCCESS
         result.task(':foo:build').outcome == TaskOutcome.SUCCESS
+        // The coverage task should run since 'coverage' was passed explicitly as an argument
         result.task(':foo:coverage').outcome == TaskOutcome.SUCCESS
-
 
         when:
         println "========================"
@@ -100,6 +100,9 @@ class PythonPluginIntegrationTest extends Specification {
         |   details {
         |       virtualEnvPrompt = 'pyGradle!'
         |   }
+        |   coverage {
+        |       run = true
+        |   }
         |}
         |
         |buildDir = 'build2'
@@ -125,7 +128,10 @@ class PythonPluginIntegrationTest extends Specification {
         result.task(':foo:createVirtualEnvironment').outcome == TaskOutcome.SUCCESS
         result.task(':foo:getProbedTags').outcome == TaskOutcome.SUCCESS
         result.task(':foo:installProject').outcome == TaskOutcome.SUCCESS
-        result.task(':foo:pytest').outcome == TaskOutcome.SUCCESS
+        // The coverage task should run since we set it in the build.gradle file
+        result.task(':foo:coverage').outcome == TaskOutcome.SUCCESS
+        // The pytest task should be skipped since we are running coverage
+        result.task(':foo:pytest').outcome == TaskOutcome.SKIPPED
         result.task(':foo:check').outcome == TaskOutcome.SUCCESS
         result.task(':foo:build').outcome == TaskOutcome.SUCCESS
         !installOrderSorted(result.output, ':foo:installSetupRequirements', ':foo:installBuildRequirements')

--- a/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/testutils/DefaultProjectLayoutRule.groovy
+++ b/pygradle-plugin/src/integTest/groovy/com/linkedin/gradle/python/plugin/testutils/DefaultProjectLayoutRule.groovy
@@ -48,6 +48,8 @@ class DefaultProjectLayoutRule extends ExternalResource implements ProjectLayout
     }
 
     public File buildFile
+    public File setupCfg
+    public File testFile
 
     @Override
     void before() throws Throwable {
@@ -133,10 +135,10 @@ class DefaultProjectLayoutRule extends ExternalResource implements ProjectLayout
         newFile(Paths.get(PROJECT_NAME_DIR, 'setup.py').toString()) << PyGradleTestBuilder.createSetupPy()
 
         // Create the setup.cfg file
-        newFile(Paths.get(PROJECT_NAME_DIR, 'setup.cfg').toString()) << PyGradleTestBuilder.createSetupCfg()
+        setupCfg = newFile(Paths.get(PROJECT_NAME_DIR, 'setup.cfg').toString()) << PyGradleTestBuilder.createSetupCfg()
 
         // Create the test directory and a simple test
-        newFile(Paths.get(PROJECT_NAME_DIR, 'test', 'test_a.py').toString()) << '''\
+        testFile = newFile(Paths.get(PROJECT_NAME_DIR, 'test', 'test_a.py').toString()) << '''\
             | from foo.hello import generate_welcome
             |
             |

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
@@ -76,6 +76,7 @@ class PyCoverageTask extends PyTestTask {
 
         CoverageXmlReporter coverageXmlReport = new CoverageXmlReporter(coverage)
         coverageReport.text = coverageXmlReport.generateXML()
+        super.processResults(execResult)
     }
 
     static class ParseOutputStream {

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
@@ -34,10 +34,14 @@ import java.util.regex.Pattern
 class PyCoverageTask extends PyTestTask {
 
     @OutputDirectory
-    File coverageOutputDir = project.file("${ project.buildDir }/coverage")
+    File getCoverageOutputDir() {
+        return project.file("${ project.buildDir }/coverage")
+    }
 
     @OutputFile
-    File coverageReport = project.file("${ project.buildDir }/coverage/coverage.xml")
+    File getCoverageReport() {
+        return project.file("${ project.buildDir }/coverage/coverage.xml")
+    }
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
 

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
@@ -21,7 +21,6 @@ import groovy.transform.CompileStatic
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.output.TeeOutputStream
 import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.OutputFile
 import org.gradle.process.ExecResult
 
 import java.util.regex.Pattern
@@ -38,8 +37,7 @@ class PyCoverageTask extends PyTestTask {
         return project.file("${ project.buildDir }/coverage")
     }
 
-    @OutputFile
-    File getCoverageReport() {
+    private File getCoverageReport() {
         return project.file("${ project.buildDir }/coverage/coverage.xml")
     }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.10.13
+version=0.11.0


### PR DESCRIPTION
Currently, if coverage is enabled for a build, the pytest
task is run and then the coverage task is run, which inherits
from the pytest task, and consequently, the pytest suite is
run twice. Added logic to ensure the either pytest XOR coverage
task is part of the build. Also added logic to existing
integration tests (PythonPluginIntegrationTest, PexIntegrationTest)
to verify that the coverage/pytest tasks are skipped when expected