### PR TITLE
Added a null check for the htmlDir in PyCoverageTask

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
@@ -73,8 +73,10 @@ class PyCoverageTask extends PyTestTask {
         String htmlDir = streamProcessor.htmlDir
         String coverage = streamProcessor.coverage
 
-
-        FileUtils.copyDirectoryToDirectory(project.file(htmlDir), coverageOutputDir)
+        // If there is no coverage to report, then the htmlDir value will be empty
+        if (htmlDir != null) {
+            FileUtils.copyDirectoryToDirectory(project.file(htmlDir), coverageOutputDir)
+        }
 
         CoverageXmlReporter coverageXmlReport = new CoverageXmlReporter(coverage)
         coverageReport.text = coverageXmlReport.generateXML()


### PR DESCRIPTION
Handling of an edge case: If the user configures the project
to run covergae but there is no coverage output (i.e. no
coverage to report), the htmlDir parsed from the output will
ultimately be null, and thus the call to project.file(htmlDir)
fails with IllegalArgumentException: path may not be null or
empty string. path='null'