### PR TITLE
Keep flake8 configuration for compatibility.

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/plugin/PythonPlugin.java
@@ -160,6 +160,8 @@ public class PythonPlugin implements Plugin<Project> {
         project.getConfigurations().create(CONFIGURATION_TEST.getValue());
         project.getConfigurations().create(CONFIGURATION_VENV.getValue());
         project.getConfigurations().create(CONFIGURATION_WHEEL.getValue());
+        // TODO: Kept for compatibility. Remove when not needed (very soon).
+        project.getConfigurations().create("flake8");
     }
 
     /*


### PR DESCRIPTION
We need this just a little longer, but will remove it very soon.