### PR TITLE
Minor bug fix for Flake8 Task

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -136,11 +136,11 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
 
     @TaskAction
     public void executeTask() {
+        preExecution();
         executePythonProcess();
     }
 
     void executePythonProcess() {
-        preExecution();
 
         final TeeOutputContainer container = new TeeOutputContainer(stdOut, errOut);
 


### PR DESCRIPTION
We don't want to perform the preExecution() function
twice in the flake8 task, since it is adding arguements
and subarguments and we don't want to do that again.
To enforce this, I moved the call to preExecution()
into the task action in AbstractPythonMainSourceDefaultTask
and out of the executePythonProcess() method.