### PR TITLE
Update Groovy to 2.5.8

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.5'
+    compile 'org.codehaus.groovy:groovy-all:2.5.8'
     compile 'org.apache.httpcomponents:fluent-hc:4.5.1'
     compile 'commons-cli:commons-cli:1.3.1'
     compile 'ch.qos.logback:logback-classic:1.1.3'


### PR DESCRIPTION
    This is a minimal change required to get pivy-importer
    JAR to work with Java 13. Otherwise, we may see errors like:

    ```
    $ java -jar ../etc/pivy-importer-0.12.8-all.jar --repo local-ivy-repo numpy:1.14.5

    WARNING: An illegal reflective access operation has occurred
    WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass$3$1 (file:/../pivy-importer-0.12.8-all.jar) to method java.lang.Object.finalize()
    WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass$3$1
    WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
    WARNING: All illegal access operations will be denied in a future release
    Exception in thread "main" java.lang.ClassCastException: class [B cannot be cast to class [C ([B and [C are in module java.base of loader 'bootstrap')
            at groovy.json.internal.FastStringUtils$StringImplementation$1.toCharArray(FastStringUtils.java:90)
            at groovy.json.internal.FastStringUtils.toCharArray(FastStringUtils.java:175)
            at groovy.json.internal.BaseJsonParser.parse(BaseJsonParser.java:104)
            at groovy.json.JsonSlurper.parseText(JsonSlurper.java:205)
            at groovy.json.JsonSlurper$parseText.call(Unknown Source)
            at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
            at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
            at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
            at com.linkedin.python.importer.pypi.PypiApiCache.downloadMetadata(PypiApiCache.groovy:57)
    ```