### PR TITLE
Changed PyCoverageTask to use getters for coverage outputs

### DIFF
--- a/pivy-importer/build.gradle
+++ b/pivy-importer/build.gradle
@@ -48,6 +48,7 @@ task importRequiredDependencies(type: JavaExec) { task ->
         'PyYAML:3.02=PyYAML:3.12',
         'setuptools:0.6a2=setuptools:19.1.1',               // candidate for removal
         'setuptools:0.6c1=setuptools:19.1.1',
+        'sphinxcontrib-websupport:1.2.0=sphinxcontrib-websupport:1.1.2',
         'sphinx_rtd_theme:0.1=sphinx_rtd_theme:0.1.1',      // candidate for removal
         'sphinx_rtd_theme:0.1.0=sphinx_rtd_theme:0.1.1',      // candidate for removal
     ].join(",")

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
@@ -75,11 +75,11 @@ class PyCoverageTask extends PyTestTask {
 
         // If there is no coverage to report, then the htmlDir value will be empty
         if (htmlDir != null) {
-            FileUtils.copyDirectoryToDirectory(project.file(htmlDir), coverageOutputDir)
+            FileUtils.copyDirectoryToDirectory(project.file(htmlDir), getCoverageOutputDir())
         }
 
         CoverageXmlReporter coverageXmlReport = new CoverageXmlReporter(coverage)
-        coverageReport.text = coverageXmlReport.generateXML()
+        getCoverageReport().text = coverageXmlReport.generateXML()
         super.processResults(execResult)
     }
 


### PR DESCRIPTION
There was a bug in which the getters for the coverage output
file and directory were not being used, resulting in a
documentated coverage of 0.