### PR TITLE
Gradle 7 Compatibility

### DIFF
--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/AbstractPythonMainSourceDefaultTask.java
@@ -76,6 +76,7 @@ abstract public class AbstractPythonMainSourceDefaultTask extends DefaultTask im
         return new String[]{"**/*.pyc", "**/*.pyo", "**/__pycache__/", "**/*.egg-info/"};
     }
 
+    @Internal
     public PythonExtension getPythonExtension() {
         if (null == extension) {
             extension = getProject().getExtensions().getByType(PythonExtension.class);

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/BuildWheelsTask.groovy
@@ -162,6 +162,7 @@ class BuildWheelsTask extends DefaultTask implements SupportsWheelCache, Support
     }
 
     @Override
+    @Internal
     String getReason() {
         return lastInstallMessage
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/Flake8Task.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/Flake8Task.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.process.ExecResult;
 
 import java.io.File;
@@ -53,6 +55,8 @@ public class Flake8Task extends AbstractPythonMainSourceDefaultTask {
         this.ignoreRules = ignoreRules;
     }
 
+    @Input
+    @Optional
     public Set<String> getIgnoreRules() {
         return ignoreRules;
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/GetProbedTagsTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/GetProbedTagsTask.java
@@ -20,6 +20,7 @@ import com.linkedin.gradle.python.tasks.action.ProbeVenvInfoAction;
 import com.linkedin.gradle.python.tasks.provides.ProvidesVenv;
 import com.linkedin.gradle.python.wheel.EditablePythonAbiContainer;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
 
@@ -46,6 +47,7 @@ public class GetProbedTagsTask extends DefaultTask implements ProvidesVenv {
         this.editablePythonAbiContainer = editablePythonAbiContainer;
     }
 
+    @Input
     public PythonDetails getPythonDetails() {
         return pythonDetails;
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/InstallVirtualEnvironmentTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/InstallVirtualEnvironmentTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -59,6 +60,7 @@ public class InstallVirtualEnvironmentTask extends DefaultTask implements Failur
     }
 
     @Override
+    @Internal
     public String getReason() {
         return container.getCommandOutput();
     }
@@ -67,6 +69,7 @@ public class InstallVirtualEnvironmentTask extends DefaultTask implements Failur
         this.pythonDetails = pythonDetails;
     }
 
+    @Input
     public PythonDetails getPythonDetails() {
         return pythonDetails;
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/ParallelWheelGenerationTask.java
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/ParallelWheelGenerationTask.java
@@ -263,12 +263,14 @@ public class ParallelWheelGenerationTask extends DefaultTask implements Supports
     }
 
     @Override
+    @Internal
     public PackageSettings<PackageInfo> getPackageSettings() {
         return this.packageSettings;
     }
 
     @Nullable
     @Override
+    @Internal
     public Spec<PackageInfo> getPackageExcludeFilter() {
         return packageFilter;
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PipInstallTask.groovy
@@ -40,6 +40,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.progress.ProgressLogger
@@ -71,16 +72,21 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider, Suppo
     Map<String, String> environment
 
     @Input
-    @Optional
     boolean sorted = true
 
+    @Internal
     PackageSettings<PackageInfo> packageSettings
+
+    @Internal
     EnvironmentMerger environmentMerger = new DefaultEnvironmentMerger()
+
+    @Internal
     ExternalExec externalExec = new ProjectExternalExec(getProject())
 
     /**
      * Will return true when the package should be excluded from being installed.
      */
+    @Internal
     Spec<PackageInfo> packageExcludeFilter = null
 
     private String lastInstallMessage = null
@@ -156,6 +162,7 @@ class PipInstallTask extends DefaultTask implements FailureReasonProvider, Suppo
     }
 
     @Override
+    @Internal
     String getReason() {
         return lastInstallMessage
     }

--- a/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
+++ b/pygradle-plugin/src/main/groovy/com/linkedin/gradle/python/tasks/PyCoverageTask.groovy
@@ -45,7 +45,7 @@ class PyCoverageTask extends PyTestTask {
 
     PyCoverageTask() {
         super()
-        stdOut = new TeeOutputStream(stdOut, outputStream)
+        stdOut = new TeeOutputStream(System.out, outputStream)
     }
 
     /**


### PR DESCRIPTION
- Add missing annotations to make pygradle plugin tasks compatible with Gradle 7
- Fix issues with extra characters when writing wheel-api.py resource to file
- Update TeeOutputstream constructor to refer to static System.out instead of using self-referential assignment